### PR TITLE
Fix deprecated UUID handling in zod generator

### DIFF
--- a/output-samples/angular/full-sample/schema.ts
+++ b/output-samples/angular/full-sample/schema.ts
@@ -15,11 +15,11 @@ export const AddressSchema = z.object({
 export type Address = z.infer<typeof AddressSchema>;
 
 export const CategorySchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.uuid().nullable().optional(),
+  parentId: z.string().uuid().nullable().optional(),
   isActive: z.boolean().optional()
 });
 
@@ -29,7 +29,7 @@ export const CreateCategoryRequestSchema = z.object({
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.uuid().optional()
+  parentId: z.string().uuid().optional()
 });
 
 export type CreateCategoryRequest = z.infer<typeof CreateCategoryRequestSchema>;
@@ -42,7 +42,7 @@ export const ErrorResponseSchema = z.object({
   field: z.string().optional(),
   message: z.string().optional()
 })).optional(),
-  requestId: z.uuid().optional(),
+  requestId: z.string().uuid().optional(),
   timestamp: z.string().datetime().optional()
 })
 });
@@ -111,7 +111,7 @@ export const ProductAnalyticsSchema = z.object({
   activeProducts: z.number().min(0).int(),
   categoryBreakdown: z.object({}).optional(),
   lowStockProducts: z.array(z.object({
-  productId: z.uuid().optional(),
+  productId: z.string().uuid().optional(),
   productName: z.string().optional(),
   currentStock: z.number().int().optional(),
   threshold: z.number().int().optional()
@@ -129,7 +129,7 @@ export const SalesAnalyticsSchema = z.object({
   totalOrders: z.number().min(0).int(),
   averageOrderValue: z.number().min(0),
   topProducts: z.array(z.object({
-  productId: z.uuid().optional(),
+  productId: z.string().uuid().optional(),
   productName: z.string().optional(),
   revenue: z.number().optional(),
   unitsSold: z.number().int().optional()
@@ -166,7 +166,7 @@ export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const InventoryResponseSchema = z.object({
   data: z.array(z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   productName: z.string().optional(),
   inventory: InventorySchema
 }))
@@ -192,7 +192,7 @@ export type UpdateOrderStatusRequest = z.infer<typeof UpdateOrderStatusRequestSc
 
 export const CreateOrderRequestSchema = z.object({
   items: z.array(z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   quantity: z.number().min(1).int()
 })),
   shippingAddress: AddressSchema,
@@ -203,7 +203,7 @@ export const CreateOrderRequestSchema = z.object({
 export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
 
 export const ProductSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   price: PriceSchema,
@@ -238,7 +238,7 @@ export const CreateUserRequestSchema = z.object({
 export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
 
 export const UserSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   email: z.string().email(),
   profile: UserProfileSchema,
   preferences: UserPreferencesSchema.optional(),
@@ -251,7 +251,7 @@ export const UserSchema = z.object({
 export type User = z.infer<typeof UserSchema>;
 
 export const OrderItemSchema = z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   quantity: z.number().min(1).int(),
   price: PriceSchema,
   productSnapshot: ProductSchema.optional()
@@ -281,8 +281,8 @@ export const UserListResponseSchema = z.object({
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
 export const OrderSchema = z.object({
-  id: z.uuid(),
-  userId: z.uuid(),
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
   items: z.array(OrderItemSchema),
   total: PriceSchema,
   status: OrderStatusSchema,

--- a/output-samples/angular/full-sample/schema.ts
+++ b/output-samples/angular/full-sample/schema.ts
@@ -15,11 +15,11 @@ export const AddressSchema = z.object({
 export type Address = z.infer<typeof AddressSchema>;
 
 export const CategorySchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.string().uuid().nullable().optional(),
+  parentId: z.uuid().nullable().optional(),
   isActive: z.boolean().optional()
 });
 
@@ -29,7 +29,7 @@ export const CreateCategoryRequestSchema = z.object({
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.string().uuid().optional()
+  parentId: z.uuid().optional()
 });
 
 export type CreateCategoryRequest = z.infer<typeof CreateCategoryRequestSchema>;
@@ -42,7 +42,7 @@ export const ErrorResponseSchema = z.object({
   field: z.string().optional(),
   message: z.string().optional()
 })).optional(),
-  requestId: z.string().uuid().optional(),
+  requestId: z.uuid().optional(),
   timestamp: z.string().datetime().optional()
 })
 });
@@ -111,7 +111,7 @@ export const ProductAnalyticsSchema = z.object({
   activeProducts: z.number().min(0).int(),
   categoryBreakdown: z.object({}).optional(),
   lowStockProducts: z.array(z.object({
-  productId: z.string().uuid().optional(),
+  productId: z.uuid().optional(),
   productName: z.string().optional(),
   currentStock: z.number().int().optional(),
   threshold: z.number().int().optional()
@@ -129,7 +129,7 @@ export const SalesAnalyticsSchema = z.object({
   totalOrders: z.number().min(0).int(),
   averageOrderValue: z.number().min(0),
   topProducts: z.array(z.object({
-  productId: z.string().uuid().optional(),
+  productId: z.uuid().optional(),
   productName: z.string().optional(),
   revenue: z.number().optional(),
   unitsSold: z.number().int().optional()
@@ -166,7 +166,7 @@ export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const InventoryResponseSchema = z.object({
   data: z.array(z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   productName: z.string().optional(),
   inventory: InventorySchema
 }))
@@ -192,7 +192,7 @@ export type UpdateOrderStatusRequest = z.infer<typeof UpdateOrderStatusRequestSc
 
 export const CreateOrderRequestSchema = z.object({
   items: z.array(z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   quantity: z.number().min(1).int()
 })),
   shippingAddress: AddressSchema,
@@ -203,7 +203,7 @@ export const CreateOrderRequestSchema = z.object({
 export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
 
 export const ProductSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   price: PriceSchema,
@@ -238,7 +238,7 @@ export const CreateUserRequestSchema = z.object({
 export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
 
 export const UserSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   email: z.string().email(),
   profile: UserProfileSchema,
   preferences: UserPreferencesSchema.optional(),
@@ -251,7 +251,7 @@ export const UserSchema = z.object({
 export type User = z.infer<typeof UserSchema>;
 
 export const OrderItemSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   quantity: z.number().min(1).int(),
   price: PriceSchema,
   productSnapshot: ProductSchema.optional()
@@ -281,8 +281,8 @@ export const UserListResponseSchema = z.object({
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
 export const OrderSchema = z.object({
-  id: z.string().uuid(),
-  userId: z.string().uuid(),
+  id: z.uuid(),
+  userId: z.uuid(),
   items: z.array(OrderItemSchema),
   total: PriceSchema,
   status: OrderStatusSchema,

--- a/output-samples/comprehensive-nested-test/schema.ts
+++ b/output-samples/comprehensive-nested-test/schema.ts
@@ -15,11 +15,11 @@ export const AddressSchema = z.object({
 export type Address = z.infer<typeof AddressSchema>;
 
 export const CategorySchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.uuid().nullable().optional(),
+  parentId: z.string().uuid().nullable().optional(),
   isActive: z.boolean().optional()
 });
 
@@ -29,7 +29,7 @@ export const CreateCategoryRequestSchema = z.object({
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.uuid().optional()
+  parentId: z.string().uuid().optional()
 });
 
 export type CreateCategoryRequest = z.infer<typeof CreateCategoryRequestSchema>;
@@ -42,7 +42,7 @@ export const ErrorResponseSchema = z.object({
   field: z.string().optional(),
   message: z.string().optional()
 })).optional(),
-  requestId: z.uuid().optional(),
+  requestId: z.string().uuid().optional(),
   timestamp: z.string().datetime().optional()
 })
 });
@@ -111,7 +111,7 @@ export const ProductAnalyticsSchema = z.object({
   activeProducts: z.number().min(0).int(),
   categoryBreakdown: z.object({}).optional(),
   lowStockProducts: z.array(z.object({
-  productId: z.uuid().optional(),
+  productId: z.string().uuid().optional(),
   productName: z.string().optional(),
   currentStock: z.number().int().optional(),
   threshold: z.number().int().optional()
@@ -129,7 +129,7 @@ export const SalesAnalyticsSchema = z.object({
   totalOrders: z.number().min(0).int(),
   averageOrderValue: z.number().min(0),
   topProducts: z.array(z.object({
-  productId: z.uuid().optional(),
+  productId: z.string().uuid().optional(),
   productName: z.string().optional(),
   revenue: z.number().optional(),
   unitsSold: z.number().int().optional()
@@ -166,7 +166,7 @@ export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const InventoryResponseSchema = z.object({
   data: z.array(z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   productName: z.string().optional(),
   inventory: InventorySchema
 }))
@@ -192,7 +192,7 @@ export type UpdateOrderStatusRequest = z.infer<typeof UpdateOrderStatusRequestSc
 
 export const CreateOrderRequestSchema = z.object({
   items: z.array(z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   quantity: z.number().min(1).int()
 })),
   shippingAddress: AddressSchema,
@@ -203,7 +203,7 @@ export const CreateOrderRequestSchema = z.object({
 export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
 
 export const ProductSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   price: PriceSchema,
@@ -238,7 +238,7 @@ export const CreateUserRequestSchema = z.object({
 export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
 
 export const UserSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   email: z.string().email(),
   profile: UserProfileSchema,
   preferences: UserPreferencesSchema.optional(),
@@ -251,7 +251,7 @@ export const UserSchema = z.object({
 export type User = z.infer<typeof UserSchema>;
 
 export const OrderItemSchema = z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   quantity: z.number().min(1).int(),
   price: PriceSchema,
   productSnapshot: ProductSchema.optional()
@@ -281,8 +281,8 @@ export const UserListResponseSchema = z.object({
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
 export const OrderSchema = z.object({
-  id: z.uuid(),
-  userId: z.uuid(),
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
   items: z.array(OrderItemSchema),
   total: PriceSchema,
   status: OrderStatusSchema,

--- a/output-samples/comprehensive-nested-test/schema.ts
+++ b/output-samples/comprehensive-nested-test/schema.ts
@@ -15,11 +15,11 @@ export const AddressSchema = z.object({
 export type Address = z.infer<typeof AddressSchema>;
 
 export const CategorySchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.string().uuid().nullable().optional(),
+  parentId: z.uuid().nullable().optional(),
   isActive: z.boolean().optional()
 });
 
@@ -29,7 +29,7 @@ export const CreateCategoryRequestSchema = z.object({
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.string().uuid().optional()
+  parentId: z.uuid().optional()
 });
 
 export type CreateCategoryRequest = z.infer<typeof CreateCategoryRequestSchema>;
@@ -42,7 +42,7 @@ export const ErrorResponseSchema = z.object({
   field: z.string().optional(),
   message: z.string().optional()
 })).optional(),
-  requestId: z.string().uuid().optional(),
+  requestId: z.uuid().optional(),
   timestamp: z.string().datetime().optional()
 })
 });
@@ -111,7 +111,7 @@ export const ProductAnalyticsSchema = z.object({
   activeProducts: z.number().min(0).int(),
   categoryBreakdown: z.object({}).optional(),
   lowStockProducts: z.array(z.object({
-  productId: z.string().uuid().optional(),
+  productId: z.uuid().optional(),
   productName: z.string().optional(),
   currentStock: z.number().int().optional(),
   threshold: z.number().int().optional()
@@ -129,7 +129,7 @@ export const SalesAnalyticsSchema = z.object({
   totalOrders: z.number().min(0).int(),
   averageOrderValue: z.number().min(0),
   topProducts: z.array(z.object({
-  productId: z.string().uuid().optional(),
+  productId: z.uuid().optional(),
   productName: z.string().optional(),
   revenue: z.number().optional(),
   unitsSold: z.number().int().optional()
@@ -166,7 +166,7 @@ export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const InventoryResponseSchema = z.object({
   data: z.array(z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   productName: z.string().optional(),
   inventory: InventorySchema
 }))
@@ -192,7 +192,7 @@ export type UpdateOrderStatusRequest = z.infer<typeof UpdateOrderStatusRequestSc
 
 export const CreateOrderRequestSchema = z.object({
   items: z.array(z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   quantity: z.number().min(1).int()
 })),
   shippingAddress: AddressSchema,
@@ -203,7 +203,7 @@ export const CreateOrderRequestSchema = z.object({
 export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
 
 export const ProductSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   price: PriceSchema,
@@ -238,7 +238,7 @@ export const CreateUserRequestSchema = z.object({
 export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
 
 export const UserSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   email: z.string().email(),
   profile: UserProfileSchema,
   preferences: UserPreferencesSchema.optional(),
@@ -251,7 +251,7 @@ export const UserSchema = z.object({
 export type User = z.infer<typeof UserSchema>;
 
 export const OrderItemSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   quantity: z.number().min(1).int(),
   price: PriceSchema,
   productSnapshot: ProductSchema.optional()
@@ -281,8 +281,8 @@ export const UserListResponseSchema = z.object({
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
 export const OrderSchema = z.object({
-  id: z.string().uuid(),
-  userId: z.string().uuid(),
+  id: z.uuid(),
+  userId: z.uuid(),
   items: z.array(OrderItemSchema),
   total: PriceSchema,
   status: OrderStatusSchema,

--- a/output-samples/nested-test/schema.ts
+++ b/output-samples/nested-test/schema.ts
@@ -15,11 +15,11 @@ export const AddressSchema = z.object({
 export type Address = z.infer<typeof AddressSchema>;
 
 export const CategorySchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.uuid().nullable().optional(),
+  parentId: z.string().uuid().nullable().optional(),
   isActive: z.boolean().optional()
 });
 
@@ -29,7 +29,7 @@ export const CreateCategoryRequestSchema = z.object({
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.uuid().optional()
+  parentId: z.string().uuid().optional()
 });
 
 export type CreateCategoryRequest = z.infer<typeof CreateCategoryRequestSchema>;
@@ -42,7 +42,7 @@ export const ErrorResponseSchema = z.object({
   field: z.string().optional(),
   message: z.string().optional()
 })).optional(),
-  requestId: z.uuid().optional(),
+  requestId: z.string().uuid().optional(),
   timestamp: z.string().datetime().optional()
 })
 });
@@ -111,7 +111,7 @@ export const ProductAnalyticsSchema = z.object({
   activeProducts: z.number().min(0).int(),
   categoryBreakdown: z.object({}).optional(),
   lowStockProducts: z.array(z.object({
-  productId: z.uuid().optional(),
+  productId: z.string().uuid().optional(),
   productName: z.string().optional(),
   currentStock: z.number().int().optional(),
   threshold: z.number().int().optional()
@@ -129,7 +129,7 @@ export const SalesAnalyticsSchema = z.object({
   totalOrders: z.number().min(0).int(),
   averageOrderValue: z.number().min(0),
   topProducts: z.array(z.object({
-  productId: z.uuid().optional(),
+  productId: z.string().uuid().optional(),
   productName: z.string().optional(),
   revenue: z.number().optional(),
   unitsSold: z.number().int().optional()
@@ -166,7 +166,7 @@ export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const InventoryResponseSchema = z.object({
   data: z.array(z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   productName: z.string().optional(),
   inventory: InventorySchema
 }))
@@ -192,7 +192,7 @@ export type UpdateOrderStatusRequest = z.infer<typeof UpdateOrderStatusRequestSc
 
 export const CreateOrderRequestSchema = z.object({
   items: z.array(z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   quantity: z.number().min(1).int()
 })),
   shippingAddress: AddressSchema,
@@ -203,7 +203,7 @@ export const CreateOrderRequestSchema = z.object({
 export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
 
 export const ProductSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   price: PriceSchema,
@@ -238,7 +238,7 @@ export const CreateUserRequestSchema = z.object({
 export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
 
 export const UserSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   email: z.string().email(),
   profile: UserProfileSchema,
   preferences: UserPreferencesSchema.optional(),
@@ -251,7 +251,7 @@ export const UserSchema = z.object({
 export type User = z.infer<typeof UserSchema>;
 
 export const OrderItemSchema = z.object({
-  productId: z.uuid(),
+  productId: z.string().uuid(),
   quantity: z.number().min(1).int(),
   price: PriceSchema,
   productSnapshot: ProductSchema.optional()
@@ -281,8 +281,8 @@ export const UserListResponseSchema = z.object({
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
 export const OrderSchema = z.object({
-  id: z.uuid(),
-  userId: z.uuid(),
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
   items: z.array(OrderItemSchema),
   total: PriceSchema,
   status: OrderStatusSchema,

--- a/output-samples/nested-test/schema.ts
+++ b/output-samples/nested-test/schema.ts
@@ -15,11 +15,11 @@ export const AddressSchema = z.object({
 export type Address = z.infer<typeof AddressSchema>;
 
 export const CategorySchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.string().uuid().nullable().optional(),
+  parentId: z.uuid().nullable().optional(),
   isActive: z.boolean().optional()
 });
 
@@ -29,7 +29,7 @@ export const CreateCategoryRequestSchema = z.object({
   name: z.string().min(1).max(100),
   slug: z.string().regex(new RegExp("^[a-z0-9-]+$")),
   description: z.string().max(500).optional(),
-  parentId: z.string().uuid().optional()
+  parentId: z.uuid().optional()
 });
 
 export type CreateCategoryRequest = z.infer<typeof CreateCategoryRequestSchema>;
@@ -42,7 +42,7 @@ export const ErrorResponseSchema = z.object({
   field: z.string().optional(),
   message: z.string().optional()
 })).optional(),
-  requestId: z.string().uuid().optional(),
+  requestId: z.uuid().optional(),
   timestamp: z.string().datetime().optional()
 })
 });
@@ -111,7 +111,7 @@ export const ProductAnalyticsSchema = z.object({
   activeProducts: z.number().min(0).int(),
   categoryBreakdown: z.object({}).optional(),
   lowStockProducts: z.array(z.object({
-  productId: z.string().uuid().optional(),
+  productId: z.uuid().optional(),
   productName: z.string().optional(),
   currentStock: z.number().int().optional(),
   threshold: z.number().int().optional()
@@ -129,7 +129,7 @@ export const SalesAnalyticsSchema = z.object({
   totalOrders: z.number().min(0).int(),
   averageOrderValue: z.number().min(0),
   topProducts: z.array(z.object({
-  productId: z.string().uuid().optional(),
+  productId: z.uuid().optional(),
   productName: z.string().optional(),
   revenue: z.number().optional(),
   unitsSold: z.number().int().optional()
@@ -166,7 +166,7 @@ export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const InventoryResponseSchema = z.object({
   data: z.array(z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   productName: z.string().optional(),
   inventory: InventorySchema
 }))
@@ -192,7 +192,7 @@ export type UpdateOrderStatusRequest = z.infer<typeof UpdateOrderStatusRequestSc
 
 export const CreateOrderRequestSchema = z.object({
   items: z.array(z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   quantity: z.number().min(1).int()
 })),
   shippingAddress: AddressSchema,
@@ -203,7 +203,7 @@ export const CreateOrderRequestSchema = z.object({
 export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
 
 export const ProductSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).nullable().optional(),
   price: PriceSchema,
@@ -238,7 +238,7 @@ export const CreateUserRequestSchema = z.object({
 export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
 
 export const UserSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   email: z.string().email(),
   profile: UserProfileSchema,
   preferences: UserPreferencesSchema.optional(),
@@ -251,7 +251,7 @@ export const UserSchema = z.object({
 export type User = z.infer<typeof UserSchema>;
 
 export const OrderItemSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.uuid(),
   quantity: z.number().min(1).int(),
   price: PriceSchema,
   productSnapshot: ProductSchema.optional()
@@ -281,8 +281,8 @@ export const UserListResponseSchema = z.object({
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
 export const OrderSchema = z.object({
-  id: z.string().uuid(),
-  userId: z.string().uuid(),
+  id: z.uuid(),
+  userId: z.uuid(),
   items: z.array(OrderItemSchema),
   total: PriceSchema,
   status: OrderStatusSchema,

--- a/src/generators/zod.rs
+++ b/src/generators/zod.rs
@@ -233,14 +233,12 @@ impl ZodGenerator {
                             } else {
                                 zod_schema = "z.string()".to_string();
 
-                                // Handle format validations - special case for uuid which should use z.uuid() instead of z.string().uuid()
+                                // Add format validations
                                 if let Some(fmt) = format {
                                     match fmt.as_str() {
-                                        "uuid" => {
-                                            zod_schema = "z.uuid()".to_string();
-                                        }
                                         "email" => zod_schema.push_str(".email()"),
                                         "uri" => zod_schema.push_str(".url()"),
+                                        "uuid" => zod_schema.push_str(".uuid()"),
                                         "date" => zod_schema.push_str(".date()"),
                                         "date-time" => zod_schema.push_str(".datetime()"),
                                         _ => {}

--- a/src/generators/zod.rs
+++ b/src/generators/zod.rs
@@ -233,7 +233,7 @@ impl ZodGenerator {
                             } else {
                                 zod_schema = "z.string()".to_string();
 
-                                // Handle format validations - special case for uuid which should use z.uuid() instead of z.string().uuid()
+                                // Handle format validations - special case for uuid which should use z.uuid() instead of deprecated z.string().uuid()
                                 if let Some(fmt) = format {
                                     match fmt.as_str() {
                                         "uuid" => {

--- a/src/generators/zod.rs
+++ b/src/generators/zod.rs
@@ -233,12 +233,14 @@ impl ZodGenerator {
                             } else {
                                 zod_schema = "z.string()".to_string();
 
-                                // Add format validations
+                                // Handle format validations - special case for uuid which should use z.uuid() instead of z.string().uuid()
                                 if let Some(fmt) = format {
                                     match fmt.as_str() {
+                                        "uuid" => {
+                                            zod_schema = "z.uuid()".to_string();
+                                        }
                                         "email" => zod_schema.push_str(".email()"),
                                         "uri" => zod_schema.push_str(".url()"),
-                                        "uuid" => zod_schema.push_str(".uuid()"),
                                         "date" => zod_schema.push_str(".date()"),
                                         "date-time" => zod_schema.push_str(".datetime()"),
                                         _ => {}

--- a/test-suite.py
+++ b/test-suite.py
@@ -413,7 +413,7 @@ class TestSuite:
                 "private": True,
                 "dependencies": {
                     "typescript": "^5.3.0",
-                    "zod": "^3.22.0",
+                    "zod": "^4.0.0",
                     "@types/node": "^18.0.0"
                 }
             }
@@ -721,7 +721,7 @@ interface Observer<T> {
                 "private": True,
                 "dependencies": {
                     "typescript": "^5.3.0",
-                    "zod": "^3.22.0"
+                    "zod": "^4.0.0"
                 }
             }
             
@@ -729,12 +729,12 @@ interface Observer<T> {
                 # Only include basic dependencies + real Zod, we'll create fake Angular types
                 package_json["dependencies"].update({
                     "@types/node": "^18.0.0",
-                    "zod": "^3.22.0"
+                    "zod": "^4.0.0"
                 })
             else:
                 # For non-Angular projects, just Zod
                 package_json["dependencies"].update({
-                    "zod": "^3.22.0"
+                    "zod": "^4.0.0"
                 })
             
             # Write package.json


### PR DESCRIPTION
- Replace deprecated z.string().uuid() with z.uuid()
- Update zod generator to use the new Zod v4 UUID validation method
- Update expected test outputs to match new UUID format
- All tests passing with the new implementation