### PR TITLE
ci: publish binary wheels to PyPI via maturin on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,4 +170,65 @@ jobs:
         draft: false
         prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-wheels:
+    name: Build wheel (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    needs: test
+    if: github.event_name == 'release'
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set version from release tag
+      shell: bash
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        cargo install cargo-edit --locked
+        cargo set-version "$VERSION"
+
+    - name: Build wheel
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ matrix.target }}
+        args: --release --out dist
+        manylinux: auto
+
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: wheels-${{ matrix.target }}
+        path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-wheels
+    if: github.event_name == 'release'
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC token for PyPI Trusted Publishing
+    steps:
+    - name: Download all wheels
+      uses: actions/download-artifact@v8
+      with:
+        path: dist
+        pattern: wheels-*
+        merge-multiple: true
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "dtolator"
+description = "Convert OpenAPI schema JSON files to Zod schema definitions or TypeScript interfaces"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+readme = "README.md"
+dynamic = ["version"]
+
+[tool.maturin]
+bindings = "bin"


### PR DESCRIPTION
## What

Adds `pip install dtolator` as a distribution channel by packaging the existing CLI binary as platform wheels — no library/PyO3 work, just the executable.

## Changes

- **`pyproject.toml`** — maturin build backend, `bindings = "bin"`, `requires-python = ">=3.10"`, version pulled dynamically from `Cargo.toml`.
- **`.github/workflows/ci.yml`** — two new release-only jobs (run in parallel with the existing GitHub-Release binary jobs, both `needs: test`):
  - **`build-wheels`** — matrix over Linux gnu, Windows MSVC, macOS x86_64 + aarch64. Runs `cargo set-version` from the release tag *before* building, because maturin reads the wheel version from `Cargo.toml` and ignores the `VERSION` env that `build.rs` uses. This also keeps the embedded `--version` and the wheel version in sync.
  - **`publish-pypi`** — uploads all wheels via PyPI Trusted Publishing (OIDC, no stored token).

## Verified locally

`maturin build --release` → wheel builds, installs into a fresh venv, `dtolator --version` runs.

## Required one-time setup before first release (config, not code)

1. Register a Trusted Publisher on PyPI for project `dtolator` (repo, workflow `ci.yml`, environment `pypi`).
2. Create a `pypi` environment in the GitHub repo settings.

## Notes

- musl is intentionally left out of the wheel matrix — manylinux gnu covers `pip install`; the existing GitHub-Release flow still ships the musl binary.