### PR TITLE
[Postponed] Proposal: harmonize generators behind an internal IR

### DIFF
--- a/src/generators/common.rs
+++ b/src/generators/common.rs
@@ -62,6 +62,39 @@ pub fn to_pascal_case(input: &str) -> String {
         .collect()
 }
 
+/// Convert a member/property name to `snake_case`.
+///
+/// Inserts an underscore before each uppercase run boundary and treats `-`/space
+/// as separators. Falls back to `"field"` when the result would be empty.
+pub fn to_snake_case(name: &str) -> String {
+    let mut result = String::new();
+    let mut prev_was_upper = false;
+
+    for (i, ch) in name.chars().enumerate() {
+        if ch.is_uppercase() {
+            if i > 0 && !prev_was_upper {
+                result.push('_');
+            }
+            result.push(ch.to_lowercase().next().unwrap_or(ch));
+            prev_was_upper = true;
+        } else if ch == '-' || ch == ' ' {
+            if !result.ends_with('_') {
+                result.push('_');
+            }
+            prev_was_upper = false;
+        } else {
+            result.push(ch);
+            prev_was_upper = false;
+        }
+    }
+
+    if result.is_empty() {
+        "field".to_string()
+    } else {
+        result
+    }
+}
+
 /// Builder for TSDoc/JSDoc comment blocks.
 ///
 /// Handles multiline text correctly for all sections: description, `@param`, `@returns`.

--- a/src/generators/dotnet.rs
+++ b/src/generators/dotnet.rs
@@ -1,5 +1,5 @@
 use crate::generators::Generator;
-use crate::generators::ir::{self, Backend, IrDecl, IrField, IrStruct, IrType, Scalar};
+use crate::generators::ir::{self, Backend, EnumValues, IrDecl, IrField, IrStruct, IrType, Scalar};
 use crate::openapi::OpenApiSchema;
 use anyhow::Result;
 
@@ -154,20 +154,20 @@ impl Backend for DotNetBackend {
     fn decl(&self, decl: &IrDecl, out: &mut String) {
         match decl {
             IrDecl::Struct(s) => self.render_struct(s, out),
-            IrDecl::Enum {
-                name,
-                docs,
-                members,
-            } => {
+            IrDecl::Enum { name, docs, values } => {
                 Self::summary(docs.as_ref(), out);
                 out.push_str(&format!("public enum {}\n", name));
                 out.push_str("{\n");
-                for (i, member) in members.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(",\n");
+                // Only string members map to C# enum members (mirrors the
+                // original generator, which skipped non-string enum values).
+                if let EnumValues::Strings(members) = values {
+                    for (i, member) in members.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(",\n");
+                        }
+                        out.push_str(&format!("    [JsonPropertyName(\"{}\")]\n", member));
+                        out.push_str(&format!("    {}", Self::to_pascal_case(member)));
                     }
-                    out.push_str(&format!("    [JsonPropertyName(\"{}\")]\n", member));
-                    out.push_str(&format!("    {}", Self::to_pascal_case(member)));
                 }
                 out.push_str("\n}\n\n");
             }

--- a/src/generators/dotnet.rs
+++ b/src/generators/dotnet.rs
@@ -1,12 +1,9 @@
 use crate::generators::Generator;
-use crate::openapi::{
-    AdditionalProperties, OpenApiSchema, Schema, is_schema_nullable, schema_type_str,
-};
+use crate::generators::ir::{self, Backend, IrDecl, IrField, IrStruct, IrType, Scalar};
+use crate::openapi::OpenApiSchema;
 use anyhow::Result;
 
-pub struct DotNetGenerator {
-    indent_level: usize,
-}
+pub struct DotNetGenerator;
 
 impl Default for DotNetGenerator {
     fn default() -> Self {
@@ -16,158 +13,31 @@ impl Default for DotNetGenerator {
 
 impl DotNetGenerator {
     pub fn new() -> Self {
-        Self { indent_level: 0 }
+        Self
     }
+}
 
-    fn indent(&self) -> String {
-        "    ".repeat(self.indent_level)
-    }
+/// Renders the shared [`ir::IrDocument`] as C# records/enums with
+/// `System.Text.Json` attributes. The second generator migrated onto the IR
+/// (after `rust_serde`): all schema-walking happens once in `ir::lower`.
+struct DotNetBackend {
+    command: String,
+}
 
-    fn to_pascal_case(camel_case: &str) -> String {
-        if camel_case.is_empty() {
-            return camel_case.to_string();
-        }
-
-        let mut chars = camel_case.chars();
+impl DotNetBackend {
+    /// Uppercase the first character only, leaving the rest unchanged
+    /// (`isActive` -> `IsActive`). Note this differs from `common::to_pascal_case`,
+    /// which splits on whitespace.
+    fn to_pascal_case(name: &str) -> String {
+        let mut chars = name.chars();
         match chars.next() {
             None => String::new(),
             Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
         }
     }
 
-    fn generate_class(&self, name: &str, schema: &Schema) -> Result<String> {
-        let mut output = String::new();
-
-        match schema {
-            Schema::Object {
-                schema_type,
-                properties,
-                required,
-                additional_properties,
-                enum_values,
-                one_of: _,
-                any_of: _,
-                description,
-                ..
-            } => {
-                // Handle enum types - keep as enums, not records
-                if let Some(enum_vals) = enum_values {
-                    if let Some(desc) = description {
-                        output.push_str(&format!("{}/// <summary>\n", self.indent()));
-                        for line in desc.lines() {
-                            output.push_str(&format!("{}/// {}\n", self.indent(), line));
-                        }
-                        output.push_str(&format!("{}/// </summary>\n", self.indent()));
-                    }
-                    output.push_str(&format!("{}public enum {}\n", self.indent(), name));
-                    output.push_str(&format!("{}{{\n", self.indent()));
-
-                    for (i, enum_val) in enum_vals.iter().enumerate() {
-                        if let Some(val_str) = enum_val.as_str() {
-                            let enum_name = Self::to_pascal_case(val_str);
-                            if i > 0 {
-                                output.push_str(",\n");
-                            }
-                            output.push_str(&format!(
-                                "{}    [JsonPropertyName(\"{}\")]\n",
-                                self.indent(),
-                                val_str
-                            ));
-                            output.push_str(&format!("{}    {}", self.indent(), enum_name));
-                        }
-                    }
-                    output.push_str(&format!("\n{}}}\n\n", self.indent()));
-                    return Ok(output);
-                }
-
-                // Handle map types (additionalProperties without properties)
-                if properties.is_none()
-                    && matches!(additional_properties, Some(AdditionalProperties::Schema(_)))
-                {
-                    let cs_type = self.schema_to_csharp_type(schema)?;
-                    output.push_str(&format!(
-                        "{}// Type alias: {} = {}\n\n",
-                        self.indent(),
-                        name,
-                        cs_type
-                    ));
-                    return Ok(output);
-                }
-
-                // Handle object types - generate records instead of classes
-                if schema_type_str(schema_type) == Some("object") || properties.is_some() {
-                    if let Some(desc) = description {
-                        output.push_str(&format!("{}/// <summary>\n", self.indent()));
-                        for line in desc.lines() {
-                            output.push_str(&format!("{}/// {}\n", self.indent(), line));
-                        }
-                        output.push_str(&format!("{}/// </summary>\n", self.indent()));
-                    }
-                    output.push_str(&format!("{}public record {}\n", self.indent(), name));
-                    output.push_str(&format!("{}{{\n", self.indent()));
-
-                    if let Some(props) = properties {
-                        let empty_vec = Vec::new();
-                        let required_fields = required.as_ref().unwrap_or(&empty_vec);
-
-                        for (prop_name, prop_schema) in props {
-                            let pascal_prop_name = Self::to_pascal_case(prop_name);
-                            let cs_type = self.schema_to_csharp_type(prop_schema)?;
-                            let is_required = required_fields.contains(prop_name);
-
-                            // Add JsonPropertyName attribute for camelCase conversion
-                            output.push_str(&format!(
-                                "{}    [JsonPropertyName(\"{}\")]\n",
-                                self.indent(),
-                                prop_name
-                            ));
-
-                            // Handle required vs optional properties
-                            if is_required {
-                                // Required properties use the 'required' modifier
-                                output.push_str(&format!(
-                                    "{}    public required {} {} {{ get; set; }}\n",
-                                    self.indent(),
-                                    cs_type,
-                                    pascal_prop_name
-                                ));
-                            } else {
-                                // Non-required properties are nullable
-                                let nullable_type =
-                                    if !cs_type.ends_with('?') && !cs_type.starts_with("List<") {
-                                        format!("{cs_type}?")
-                                    } else {
-                                        cs_type
-                                    };
-
-                                output.push_str(&format!(
-                                    "{}    public {} {} {{ get; set; }}\n",
-                                    self.indent(),
-                                    nullable_type,
-                                    pascal_prop_name
-                                ));
-                            }
-                        }
-                    }
-
-                    output.push_str(&format!("{}}}\n\n", self.indent()));
-                }
-            }
-            Schema::Reference { .. } => {
-                let cs_type = self.schema_to_csharp_type(schema)?;
-                output.push_str(&format!(
-                    "{}// Type alias: {} = {}\n\n",
-                    self.indent(),
-                    name,
-                    cs_type
-                ));
-            }
-        }
-
-        Ok(output)
-    }
-
-    fn is_value_type(&self, cs_type: &str) -> bool {
+    /// C# value types get a `?` suffix when nullable; reference types do not.
+    fn is_value_type(cs_type: &str) -> bool {
         matches!(
             cs_type,
             "int"
@@ -190,114 +60,139 @@ impl DotNetGenerator {
         )
     }
 
-    fn schema_to_csharp_type(&self, schema: &Schema) -> Result<String> {
-        match schema {
-            Schema::Object {
-                schema_type,
-                properties,
-                additional_properties,
-                format,
-                enum_values,
-                items,
-                nullable,
-                ..
-            } => {
-                // Handle enum values
-                if enum_values.is_some() {
-                    return Ok("string".to_string());
-                }
-
-                let base_type = if let Some(type_str) = schema_type_str(schema_type) {
-                    match type_str {
-                        "string" => match format.as_deref() {
-                            Some("uuid") => "Guid",
-                            Some("date") => "DateOnly",
-                            Some("date-time") => "DateTime",
-                            Some("byte") => "byte[]",
-                            _ => "string",
-                        },
-                        "integer" => match format.as_deref() {
-                            Some("int64") => "long",
-                            _ => "int",
-                        },
-                        "number" => match format.as_deref() {
-                            Some("float") => "float",
-                            Some("decimal") => "decimal",
-                            _ => "double",
-                        },
-                        "boolean" => "bool",
-                        "array" => {
-                            if let Some(item_schema) = items {
-                                let item_type = self.schema_to_csharp_type(item_schema)?;
-                                return Ok(format!("List<{item_type}>"));
-                            } else {
-                                "List<object>"
-                            }
-                        }
-                        "object" => {
-                            if properties.is_none()
-                                && let Some(AdditionalProperties::Schema(ap_schema)) =
-                                    additional_properties
-                            {
-                                let value_type = self.schema_to_csharp_type(ap_schema)?;
-                                return Ok(format!("Dictionary<string, {value_type}>"));
-                            }
-                            "Dictionary<string, object>"
-                        }
-                        _ => "object",
-                    }
-                } else {
-                    "object"
-                }
-                .to_string();
-
-                Ok(
-                    if is_schema_nullable(nullable, schema_type) && self.is_value_type(&base_type) {
-                        format!("{base_type}?")
-                    } else {
-                        base_type
-                    },
-                )
+    fn summary(docs: Option<&String>, out: &mut String) {
+        if let Some(desc) = docs {
+            out.push_str("/// <summary>\n");
+            for line in desc.lines() {
+                out.push_str(&format!("/// {}\n", line));
             }
-            Schema::Reference { reference, .. } => {
-                let type_name = reference
-                    .strip_prefix("#/components/schemas/")
-                    .unwrap_or(reference);
-                Ok(type_name.to_string())
+            out.push_str("/// </summary>\n");
+        }
+    }
+
+    fn render_field(&self, field: &IrField, out: &mut String) {
+        let pascal = Self::to_pascal_case(&field.wire_name);
+        let cs_type = self.type_ref(&field.ty);
+
+        out.push_str(&format!("    [JsonPropertyName(\"{}\")]\n", field.wire_name));
+        if field.required {
+            out.push_str(&format!(
+                "    public required {} {} {{ get; set; }}\n",
+                cs_type, pascal
+            ));
+        } else {
+            // Non-required properties become nullable (unless already nullable
+            // or a collection, which is non-null but possibly empty).
+            let nullable_type = if !cs_type.ends_with('?') && !cs_type.starts_with("List<") {
+                format!("{cs_type}?")
+            } else {
+                cs_type
+            };
+            out.push_str(&format!(
+                "    public {} {} {{ get; set; }}\n",
+                nullable_type, pascal
+            ));
+        }
+    }
+
+    fn render_struct(&self, s: &IrStruct, out: &mut String) {
+        Self::summary(s.docs.as_ref(), out);
+        out.push_str(&format!("public record {}\n", s.name));
+        out.push_str("{\n");
+        for field in &s.fields {
+            self.render_field(field, out);
+        }
+        out.push_str("}\n\n");
+    }
+}
+
+impl Backend for DotNetBackend {
+    fn type_ref(&self, ty: &IrType) -> String {
+        match ty {
+            // Nullable value types take a `?`; reference types are already
+            // nullable references and are left untouched here.
+            IrType::Optional(inner) => {
+                let base = self.type_ref(inner);
+                if Self::is_value_type(&base) {
+                    format!("{base}?")
+                } else {
+                    base
+                }
+            }
+            IrType::Named(name) => name.clone(),
+            IrType::Array(inner) => format!("List<{}>", self.type_ref(inner)),
+            IrType::Map(value) => format!("Dictionary<string, {}>", self.type_ref(value)),
+            IrType::Enum(_) => "string".to_string(),
+            IrType::Union(_) => "object".to_string(),
+            IrType::Scalar { kind, format } => match kind {
+                Scalar::String => match format.as_deref() {
+                    Some("uuid") => "Guid",
+                    Some("date") => "DateOnly",
+                    Some("date-time") => "DateTime",
+                    Some("byte") => "byte[]",
+                    _ => "string",
+                }
+                .to_string(),
+                Scalar::Integer => match format.as_deref() {
+                    Some("int64") => "long",
+                    _ => "int",
+                }
+                .to_string(),
+                Scalar::Number => match format.as_deref() {
+                    Some("float") => "float",
+                    Some("decimal") => "decimal",
+                    _ => "double",
+                }
+                .to_string(),
+                Scalar::Boolean => "bool".to_string(),
+                Scalar::Object => "Dictionary<string, object>".to_string(),
+                Scalar::Free => "object".to_string(),
+            },
+        }
+    }
+
+    fn decl(&self, decl: &IrDecl, out: &mut String) {
+        match decl {
+            IrDecl::Struct(s) => self.render_struct(s, out),
+            IrDecl::Enum {
+                name,
+                docs,
+                members,
+            } => {
+                Self::summary(docs.as_ref(), out);
+                out.push_str(&format!("public enum {}\n", name));
+                out.push_str("{\n");
+                for (i, member) in members.iter().enumerate() {
+                    if i > 0 {
+                        out.push_str(",\n");
+                    }
+                    out.push_str(&format!("    [JsonPropertyName(\"{}\")]\n", member));
+                    out.push_str(&format!("    {}", Self::to_pascal_case(member)));
+                }
+                out.push_str("\n}\n\n");
+            }
+            IrDecl::Alias { name, ty, .. } => {
+                out.push_str(&format!("// Type alias: {} = {}\n\n", name, self.type_ref(ty)));
             }
         }
+    }
+
+    fn preamble(&self, _doc: &ir::IrDocument, out: &mut String) {
+        out.push_str(&format!("// Generated by {}\n", self.command));
+        out.push_str("// Do not modify manually\n\n");
+        out.push_str("using System.ComponentModel.DataAnnotations;\n");
+        out.push_str("using System.Text.Json.Serialization;\n\n");
     }
 }
 
 impl Generator for DotNetGenerator {
     fn generate_with_command(&self, schema: &OpenApiSchema, command: &str) -> Result<String> {
-        let mut output = String::new();
-
-        // Add header comment
-        output.push_str(&format!("// Generated by {command}\n"));
-        output.push_str("// Do not modify manually\n\n");
-
-        // Add using statements
-        output.push_str("using System.ComponentModel.DataAnnotations;\n");
-        output.push_str("using System.Text.Json.Serialization;\n\n");
-
-        if let Some(components) = &schema.components
-            && let Some(schemas) = &components.schemas
-        {
-            for (name, schema_def) in schemas {
-                let class_def = self.generate_class(name, schema_def)?;
-                output.push_str(&class_def);
-            }
-        }
-
-        Ok(output)
-    }
-}
-
-impl Clone for DotNetGenerator {
-    fn clone(&self) -> Self {
-        Self {
-            indent_level: self.indent_level,
-        }
+        // C# emits all types in one namespace and tolerates forward references,
+        // so source declaration order is preserved (no topological sort).
+        let document = ir::lower(schema);
+        let backend = DotNetBackend {
+            command: command.to_string(),
+        };
+        Ok(backend.render(&document))
     }
 }

--- a/src/generators/ir.rs
+++ b/src/generators/ir.rs
@@ -1,103 +1,132 @@
-//! Intermediate representation (IR) for code generation — PROPOSAL / FOR DISCUSSION.
+//! Intermediate representation (IR) for code generation.
 //!
 //! Today every generator under `src/generators/` consumes `&OpenApiSchema`
 //! directly and re-implements the same schema walking in slightly different
-//! ways (`$ref` resolution, nullable/optional handling, inline-object
-//! extraction, `oneOf`/`anyOf`/`allOf`, topological sorting). Bugs fixed in one
-//! generator do not get fixed in the others.
+//! ways (`$ref` resolution, optional/required handling, enum/map/alias
+//! classification, topological sorting). Bugs fixed in one generator do not get
+//! fixed in the others.
 //!
-//! This module proposes the classic compiler frontend/backend split:
+//! This module is the classic compiler frontend/backend split:
 //!
 //! ```text
 //!   OpenApiSchema --lower()--> IrDocument --Backend--> target source
 //! ```
 //!
-//! `lower()` runs ONCE and absorbs all the gnarly OpenAPI-specific logic. Each
-//! backend then renders a clean, target-agnostic IR and never sees a `Schema`.
+//! `lower()` runs ONCE and absorbs the OpenAPI-specific logic. Each backend then
+//! renders a target-agnostic IR and never sees a `Schema`.
 //!
-//! Nothing is wired into the existing generators yet — this is here to react to
-//! in review. See the PR description for scope, migration path, and open
-//! questions.
+//! ## Frontends (input formats)
+//!
+//! `lower()` takes an [`OpenApiSchema`], which is also where the other input
+//! formats already converge: the CLI converts **plain JSON** (`--from-json`)
+//! and **JSON Schema** (`--from-json-schema`) into `OpenApiSchema` *before* any
+//! generator runs (see `lib.rs`). So a backend built on this IR automatically
+//! supports all three input formats — no per-format work needed.
+//!
+//! ## Status
+//!
+//! The Rust/serde generator (`rust_serde.rs`) is wired through this IR as the
+//! first proof of concept; its golden tests pass byte-for-byte. Other backends
+//! still walk `Schema` directly and can be migrated one at a time.
 
-use crate::openapi::{OpenApiSchema, Schema, SchemaType};
-use indexmap::IndexMap;
+use crate::generators::common;
+use crate::openapi::{AdditionalProperties, OpenApiSchema, Schema, schema_type_str};
 
 // ---------------------------------------------------------------------------
 // The IR
 // ---------------------------------------------------------------------------
 
-/// A scalar type, independent of any target language.
-///
-/// Each backend maps these to its own spelling, e.g. `Prim::Int` becomes
-/// `number` (TS), `int` (Python/C#), `i64` (Rust), `z.number().int()` (Zod).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Prim {
+/// A scalar/leaf type, independent of any target language. `format` carries the
+/// OpenAPI `format` hint (e.g. `int32`, `double`, `date-time`) so backends that
+/// distinguish widths/representations can, while others ignore it.
+#[derive(Debug, Clone)]
+pub enum Scalar {
     String,
-    Int,
-    Float,
-    Bool,
-    /// `format: binary` / byte payloads.
-    Bytes,
-    /// `format: date-time` / `date`.
-    DateTime,
-    /// No constraints — `any`/`object`/`unknown` depending on backend.
-    Any,
+    Integer,
+    Number,
+    Boolean,
+    /// Unconstrained — `object`/`any`/free-form JSON.
+    Free,
 }
 
-/// A target-agnostic type. No OpenAPI concepts leak past lowering: nullability,
-/// `$ref`, and inline objects are all already resolved into these variants.
+/// A target-agnostic type reference. `$ref`s are resolved to [`IrType::Named`];
+/// nullability and not-required are kept on separate axes (see [`IrField`]).
 #[derive(Debug, Clone)]
 pub enum IrType {
-    Prim(Prim),
-    /// Reference to a top-level model by name (already normalized).
+    Scalar {
+        kind: Scalar,
+        format: Option<String>,
+    },
+    /// Reference to a top-level declaration by name (already normalized).
     Named(String),
     Array(Box<IrType>),
     /// `additionalProperties` — a string-keyed map of the inner type.
     Map(Box<IrType>),
-    /// `nullable` / not-`required` collapsed into one place.
+    /// Schema-level nullability (`nullable: true` / type array includes `null`).
+    /// Distinct from a field being not-`required`; backends combine the two.
     Optional(Box<IrType>),
     /// `oneOf` / `anyOf`.
     Union(Vec<IrType>),
-    /// An anonymous inline object. Lowering MAY instead hoist these into named
-    /// `IrModel`s — see the open question in the PR description.
-    Object(IrObject),
-    /// A closed set of string values.
+    /// A closed set of string values used inline (not as a named type).
     Enum(Vec<String>),
 }
 
-/// An object shape (fields + their types).
-#[derive(Debug, Clone, Default)]
-pub struct IrObject {
-    pub fields: Vec<IrField>,
-}
-
-/// One field of an object/model.
+/// One field of a struct/model.
 #[derive(Debug, Clone)]
 pub struct IrField {
-    /// Name as it appears in the wire format (the JSON key).
+    /// The wire/JSON key, verbatim.
     pub wire_name: String,
     pub ty: IrType,
-    /// Whether the field is required. Note `Optional` (nullable) is a property
-    /// of `ty`; this is the separate "may be absent" axis.
+    /// Whether the field is required. Orthogonal to `IrType::Optional`
+    /// (nullability) — a backend decides how to render each combination.
     pub required: bool,
     pub docs: Option<String>,
 }
 
-/// A named, top-level model (what becomes a `interface`/`class`/`struct`).
+/// A named object declaration (becomes an `interface`/`class`/`struct`).
 #[derive(Debug, Clone)]
-pub struct IrModel {
+pub struct IrStruct {
     pub name: String,
-    pub object: IrObject,
     pub docs: Option<String>,
+    pub fields: Vec<IrField>,
+    /// The source schema had `oneOf`/`anyOf` variants that this flat struct
+    /// could not fully model. Backends may surface this (e.g. as a note).
+    pub has_unmodeled_variants: bool,
 }
 
-/// The whole lowered document handed to a backend.
+/// A top-level declaration.
+#[derive(Debug, Clone)]
+pub enum IrDecl {
+    Struct(IrStruct),
+    /// A named closed set of string values.
+    Enum {
+        name: String,
+        docs: Option<String>,
+        members: Vec<String>,
+    },
+    /// A named type alias / newtype (maps, integer enums, scalars, refs).
+    Alias {
+        name: String,
+        docs: Option<String>,
+        ty: IrType,
+    },
+}
+
+impl IrDecl {
+    pub fn name(&self) -> &str {
+        match self {
+            IrDecl::Struct(s) => &s.name,
+            IrDecl::Enum { name, .. } => name,
+            IrDecl::Alias { name, .. } => name,
+        }
+    }
+}
+
+/// The whole lowered document handed to a backend. `decls` are topologically
+/// sorted so a backend can emit top-to-bottom without forward references.
 #[derive(Debug, Clone, Default)]
 pub struct IrDocument {
-    /// Topologically sorted so a backend can emit top-to-bottom without
-    /// forward references. (Lowering owns the sort that today lives in
-    /// `common.rs` and a duplicate in `python_dict.rs`.)
-    pub models: Vec<IrModel>,
+    pub decls: Vec<IrDecl>,
     // pub endpoints: Vec<IrEndpoint>,  // follow-up: lower paths/operations
 }
 
@@ -105,87 +134,24 @@ pub struct IrDocument {
 // Backend trait — a thin convention for the type-emitting generators.
 // ---------------------------------------------------------------------------
 
-/// Renders an [`IrDocument`] to a target language.
-///
-/// Deliberately NOT a per-node visitor (`render_array`, `render_optional`, …):
-/// that fights the borrow checker and forces awkward state threading. A single
-/// `type_ref` that recurses internally matches how the generators already work.
+/// Renders an [`IrDocument`] to a target language. Deliberately NOT a per-node
+/// visitor: a single `type_ref` that recurses internally matches how the
+/// generators already work and avoids threading writer state through every node.
 pub trait Backend {
-    /// Render a type in reference position, e.g. the right-hand side of a field
-    /// declaration: `string | null`, `Optional[str]`, `z.string().nullable()`.
+    /// Render a type in reference position (right-hand side of a field).
     fn type_ref(&self, ty: &IrType) -> String;
+    /// Render one declaration into the output buffer.
+    fn decl(&self, decl: &IrDecl, out: &mut String);
+    /// File header / imports. Default: nothing.
+    fn preamble(&self, _doc: &IrDocument, _out: &mut String) {}
 
-    /// Render one named model into `w`.
-    fn model(&self, model: &IrModel, w: &mut CodeWriter);
-
-    /// Imports / file header. Default: nothing.
-    fn preamble(&self, _doc: &IrDocument, _w: &mut CodeWriter) {}
-
-    /// Drive the whole document. Most backends won't need to override this.
     fn render(&self, doc: &IrDocument) -> String {
-        let mut w = CodeWriter::new(self.indent_unit());
-        self.preamble(doc, &mut w);
-        for model in &doc.models {
-            self.model(model, &mut w);
+        let mut out = String::new();
+        self.preamble(doc, &mut out);
+        for decl in &doc.decls {
+            self.decl(decl, &mut out);
         }
-        w.finish()
-    }
-
-    /// The indentation unit for this language ("  " or "    ").
-    fn indent_unit(&self) -> &'static str {
-        "  "
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Shared writer — replaces the per-generator `indent_level` + `repeat` dance.
-// ---------------------------------------------------------------------------
-
-/// Accumulates source text with managed indentation. Replaces the
-/// `indent_level: usize` + `"  ".repeat(n)` pattern copied across generators.
-pub struct CodeWriter {
-    buf: String,
-    unit: &'static str,
-    level: usize,
-}
-
-impl CodeWriter {
-    pub fn new(unit: &'static str) -> Self {
-        Self {
-            buf: String::new(),
-            unit,
-            level: 0,
-        }
-    }
-
-    pub fn indent(&mut self) {
-        self.level += 1;
-    }
-
-    pub fn dedent(&mut self) {
-        self.level = self.level.saturating_sub(1);
-    }
-
-    /// Write one indented line (no trailing newline needed in `text`).
-    pub fn line(&mut self, text: &str) {
-        if text.is_empty() {
-            self.buf.push('\n');
-            return;
-        }
-        for _ in 0..self.level {
-            self.buf.push_str(self.unit);
-        }
-        self.buf.push_str(text);
-        self.buf.push('\n');
-    }
-
-    /// A blank separator line.
-    pub fn blank(&mut self) {
-        self.buf.push('\n');
-    }
-
-    pub fn finish(self) -> String {
-        self.buf
+        out
     }
 }
 
@@ -193,74 +159,143 @@ impl CodeWriter {
 // Lowering: OpenApiSchema -> IrDocument
 // ---------------------------------------------------------------------------
 
-/// Lower a parsed OpenAPI document into the IR.
-///
-/// Partial implementation covering the common object/field cases — enough to
-/// show the shape against the real `Schema` type. `allOf` merging, full
-/// `oneOf`/`anyOf` discrimination, and path/operation lowering are intentionally
-/// left as follow-ups (see PR open questions).
+/// Lower a parsed OpenAPI document (or anything normalized into one — see the
+/// module docs on frontends) into the IR.
 pub fn lower(schema: &OpenApiSchema) -> IrDocument {
-    let mut models = Vec::new();
+    let mut decls = Vec::new();
 
     if let Some(components) = &schema.components
         && let Some(schemas) = &components.schemas
     {
-        for (name, def) in schemas {
-            models.push(lower_model(name, def));
+        // Reuse the single canonical topological sort (the one previously also
+        // re-implemented as a DFS in python_dict.rs). Fall back to natural order
+        // only if a cycle makes a total order impossible.
+        let names = common::topological_sort(schemas)
+            .unwrap_or_else(|_| schemas.keys().cloned().collect());
+        for name in names {
+            if let Some(def) = schemas.get(&name) {
+                decls.push(lower_decl(&name, def));
+            }
         }
-        // NOTE: topological sort over `models` would happen here, reusing the
-        // single Kahn's-algorithm implementation from `common.rs`.
     }
 
-    IrDocument { models }
+    IrDocument { decls }
 }
 
-fn lower_model(name: &str, schema: &Schema) -> IrModel {
+/// Classify a top-level schema into a declaration. Mirrors the structural
+/// decisions every model generator makes: map alias, enum, integer-enum alias,
+/// struct, or opaque alias.
+fn lower_decl(name: &str, schema: &Schema) -> IrDecl {
     let docs = schema.get_description().map(str::to_string);
-    let object = match schema {
+    match schema {
         Schema::Object {
+            schema_type,
             properties,
             required,
+            additional_properties,
+            enum_values,
+            all_of,
+            one_of,
+            any_of,
             ..
-        } => lower_object(properties.as_ref(), required.as_ref()),
-        // A top-level `$ref` alias or scalar newtype: model with no fields for
-        // now; a real impl would carry a type alias variant.
-        Schema::Reference { .. } => IrObject::default(),
-    };
-    IrModel {
-        name: name.to_string(),
-        object,
-        docs,
-    }
-}
-
-fn lower_object(
-    properties: Option<&IndexMap<String, Schema>>,
-    required: Option<&Vec<String>>,
-) -> IrObject {
-    let mut fields = Vec::new();
-    if let Some(props) = properties {
-        for (field_name, field_schema) in props {
-            let is_required = required.is_some_and(|r| r.iter().any(|n| n == field_name));
-            let mut ty = lower_type(field_schema);
-            // Fold nullability into the type.
-            if field_schema.is_nullable() {
-                ty = IrType::Optional(Box::new(ty));
+        } => {
+            // Map type: additionalProperties with no declared properties.
+            if properties.is_none()
+                && let Some(AdditionalProperties::Schema(value)) = additional_properties
+            {
+                return IrDecl::Alias {
+                    name: name.to_string(),
+                    docs,
+                    ty: IrType::Map(Box::new(lower_type(value))),
+                };
             }
-            fields.push(IrField {
-                wire_name: field_name.clone(),
-                ty,
-                required: is_required,
-                docs: field_schema.get_description().map(str::to_string),
-            });
+
+            // Enums: integer enums collapse to an integer alias; string enums
+            // become a named enum.
+            if let Some(values) = enum_values {
+                if values.iter().all(|v| v.is_i64() || v.is_u64()) {
+                    return IrDecl::Alias {
+                        name: name.to_string(),
+                        docs,
+                        ty: IrType::Scalar {
+                            kind: Scalar::Integer,
+                            format: None,
+                        },
+                    };
+                }
+                let members = values
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect();
+                return IrDecl::Enum {
+                    name: name.to_string(),
+                    docs,
+                    members,
+                };
+            }
+
+            // Otherwise a struct: fields come from allOf members if present,
+            // else from properties.
+            let fields = if let Some(all_of_schemas) = all_of {
+                let mut acc = Vec::new();
+                for member in all_of_schemas {
+                    if let Schema::Object {
+                        properties: Some(props),
+                        required: req,
+                        ..
+                    } = member
+                    {
+                        collect_fields(props, req.as_ref(), &mut acc);
+                    }
+                }
+                acc
+            } else if let Some(props) = properties {
+                let mut acc = Vec::new();
+                collect_fields(props, required.as_ref(), &mut acc);
+                acc
+            } else {
+                Vec::new()
+            };
+
+            let _ = schema_type; // schema_type is informational here.
+            IrDecl::Struct(IrStruct {
+                name: name.to_string(),
+                docs,
+                fields,
+                has_unmodeled_variants: one_of.is_some() || any_of.is_some(),
+            })
         }
+        // A top-level bare `$ref` (or anything else) becomes an opaque alias.
+        Schema::Reference { .. } => IrDecl::Alias {
+            name: name.to_string(),
+            docs,
+            ty: IrType::Scalar {
+                kind: Scalar::Free,
+                format: None,
+            },
+        },
     }
-    IrObject { fields }
 }
 
-/// Map a single `Schema` node to an `IrType`. This is the logic currently
-/// duplicated as `schema_to_typescript` / `schema_to_zod` / `schema_to_python_type`
-/// / etc. — here it lives exactly once.
+fn collect_fields(
+    props: &indexmap::IndexMap<String, Schema>,
+    required: Option<&Vec<String>>,
+    out: &mut Vec<IrField>,
+) {
+    for (field_name, field_schema) in props {
+        let is_required = required.is_some_and(|r| r.iter().any(|n| n == field_name));
+        out.push(IrField {
+            wire_name: field_name.clone(),
+            ty: lower_type(field_schema),
+            required: is_required,
+            docs: field_schema.get_description().map(str::to_string),
+        });
+    }
+}
+
+/// Map a single `Schema` node (in field/value position) to an `IrType`. This is
+/// the logic duplicated today as `schema_to_typescript` / `to_rust_type` /
+/// `schema_to_python_type` — here it lives once.
 fn lower_type(schema: &Schema) -> IrType {
     match schema {
         Schema::Reference { reference, .. } => IrType::Named(ref_name(reference)),
@@ -269,6 +304,7 @@ fn lower_type(schema: &Schema) -> IrType {
             items,
             enum_values,
             additional_properties,
+            properties,
             one_of,
             any_of,
             format,
@@ -278,45 +314,63 @@ fn lower_type(schema: &Schema) -> IrType {
                 return IrType::Union(variants.iter().map(lower_type).collect());
             }
             if let Some(values) = enum_values {
-                let members = values
-                    .iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect();
-                return IrType::Enum(members);
+                // String enums keep their members (useful for literal-union
+                // backends); integer enums fall through to a plain integer.
+                if values.iter().any(|v| v.is_string()) {
+                    let members = values
+                        .iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect();
+                    return IrType::Enum(members);
+                }
             }
-            match schema_type.as_ref().and_then(SchemaType::primary_type) {
+            match schema_type_str(schema_type) {
                 Some("array") => {
-                    let inner = items.as_deref().map(lower_type).unwrap_or(IrType::Prim(Prim::Any));
+                    let inner = items
+                        .as_deref()
+                        .map(lower_type)
+                        .unwrap_or(IrType::Scalar {
+                            kind: Scalar::Free,
+                            format: None,
+                        });
                     IrType::Array(Box::new(inner))
                 }
-                Some("object") | None => {
-                    if let Some(crate::openapi::AdditionalProperties::Schema(value)) =
-                        additional_properties
+                Some("object") => {
+                    if properties.is_none()
+                        && let Some(AdditionalProperties::Schema(value)) = additional_properties
                     {
                         IrType::Map(Box::new(lower_type(value)))
                     } else {
-                        IrType::Prim(Prim::Any)
+                        IrType::Scalar {
+                            kind: Scalar::Free,
+                            format: None,
+                        }
                     }
                 }
-                Some("string") => match format.as_deref() {
-                    Some("date-time") | Some("date") => IrType::Prim(Prim::DateTime),
-                    Some("binary") | Some("byte") => IrType::Prim(Prim::Bytes),
-                    _ => IrType::Prim(Prim::String),
+                Some("string") => scalar(Scalar::String, format),
+                Some("integer") => scalar(Scalar::Integer, format),
+                Some("number") => scalar(Scalar::Number, format),
+                Some("boolean") => scalar(Scalar::Boolean, format),
+                _ => IrType::Scalar {
+                    kind: Scalar::Free,
+                    format: None,
                 },
-                Some("integer") => IrType::Prim(Prim::Int),
-                Some("number") => IrType::Prim(Prim::Float),
-                Some("boolean") => IrType::Prim(Prim::Bool),
-                _ => IrType::Prim(Prim::Any),
             }
         }
+    }
+}
+
+fn scalar(kind: Scalar, format: &Option<String>) -> IrType {
+    IrType::Scalar {
+        kind,
+        format: format.clone(),
     }
 }
 
 /// `#/components/schemas/Foo` -> `Foo`.
 fn ref_name(reference: &str) -> String {
     reference
-        .rsplit('/')
-        .next()
+        .strip_prefix("#/components/schemas/")
         .unwrap_or(reference)
         .to_string()
 }

--- a/src/generators/ir.rs
+++ b/src/generators/ir.rs
@@ -98,17 +98,26 @@ pub struct IrStruct {
     pub has_unmodeled_variants: bool,
 }
 
+/// The members of a named enum, preserving their JSON value kind so each
+/// backend can render them faithfully (string enum vs. integer enum) instead of
+/// the IR collapsing one into the other.
+#[derive(Debug, Clone)]
+pub enum EnumValues {
+    Strings(Vec<String>),
+    Integers(Vec<i64>),
+}
+
 /// A top-level declaration.
 #[derive(Debug, Clone)]
 pub enum IrDecl {
     Struct(IrStruct),
-    /// A named closed set of string values.
+    /// A named closed set of values.
     Enum {
         name: String,
         docs: Option<String>,
-        members: Vec<String>,
+        values: EnumValues,
     },
-    /// A named type alias / newtype (maps, integer enums, scalars, refs).
+    /// A named type alias / newtype (maps, scalars, refs, unions).
     Alias {
         name: String,
         docs: Option<String>,
@@ -201,6 +210,93 @@ pub fn topologically_sorted(mut doc: IrDocument, schema: &OpenApiSchema) -> IrDo
     doc
 }
 
+/// Reorder declarations using a depth-first dependency walk with alphabetical
+/// tie-breaking. This is a *different* total order from [`topologically_sorted`]
+/// (Kahn's) — the python-dict generator historically used this DFS variant, and
+/// reproducing it keeps that generator's output stable. The two orderings are
+/// kept side by side here (rather than in two generators) so the divergence is
+/// visible and can be reconciled later.
+pub fn dfs_dependency_sorted(mut doc: IrDocument, schema: &OpenApiSchema) -> IrDocument {
+    let Some(schemas) = schema.components.as_ref().and_then(|c| c.schemas.as_ref()) else {
+        return doc;
+    };
+    let known: std::collections::HashSet<&str> = schemas.keys().map(String::as_str).collect();
+
+    fn deps_of(schema: &Schema, known: &std::collections::HashSet<&str>) -> Vec<String> {
+        let mut deps = std::collections::HashSet::new();
+        fn walk(s: &Schema, known: &std::collections::HashSet<&str>, out: &mut std::collections::HashSet<String>) {
+            match s {
+                Schema::Reference { reference, .. } => {
+                    if let Some(n) = reference.strip_prefix("#/components/schemas/")
+                        && known.contains(n)
+                    {
+                        out.insert(n.to_string());
+                    }
+                }
+                Schema::Object {
+                    properties,
+                    items,
+                    one_of,
+                    any_of,
+                    ..
+                } => {
+                    for p in properties.iter().flat_map(|m| m.values()) {
+                        walk(p, known, out);
+                    }
+                    if let Some(it) = items {
+                        walk(it, known, out);
+                    }
+                    for v in [one_of, any_of].into_iter().flatten().flatten() {
+                        walk(v, known, out);
+                    }
+                }
+            }
+        }
+        walk(schema, known, &mut deps);
+        let mut v: Vec<String> = deps.into_iter().collect();
+        v.sort();
+        v
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn visit(
+        name: &str,
+        schemas: &indexmap::IndexMap<String, Schema>,
+        known: &std::collections::HashSet<&str>,
+        visited: &mut std::collections::HashSet<String>,
+        in_stack: &mut std::collections::HashSet<String>,
+        order: &mut Vec<String>,
+    ) {
+        if in_stack.contains(name) || visited.contains(name) {
+            return;
+        }
+        in_stack.insert(name.to_string());
+        if let Some(def) = schemas.get(name) {
+            for dep in deps_of(def, known) {
+                visit(&dep, schemas, known, visited, in_stack, order);
+            }
+        }
+        in_stack.remove(name);
+        visited.insert(name.to_string());
+        order.push(name.to_string());
+    }
+
+    let mut keys: Vec<&String> = schemas.keys().collect();
+    keys.sort();
+    let mut order = Vec::new();
+    let mut visited = std::collections::HashSet::new();
+    let mut in_stack = std::collections::HashSet::new();
+    for key in keys {
+        visit(key, schemas, &known, &mut visited, &mut in_stack, &mut order);
+    }
+
+    let rank: std::collections::HashMap<&str, usize> =
+        order.iter().enumerate().map(|(i, n)| (n.as_str(), i)).collect();
+    doc.decls
+        .sort_by_key(|d| rank.get(d.name()).copied().unwrap_or(usize::MAX));
+    doc
+}
+
 /// Classify a top-level schema into a declaration. Mirrors the structural
 /// decisions every model generator makes: map alias, enum, integer-enum alias,
 /// struct, or opaque alias.
@@ -229,27 +325,22 @@ fn lower_decl(name: &str, schema: &Schema) -> IrDecl {
                 };
             }
 
-            // Enums: integer enums collapse to an integer alias; string enums
-            // become a named enum.
+            // Enums keep their value kind so backends render them faithfully.
             if let Some(values) = enum_values {
-                if values.iter().all(|v| v.is_i64() || v.is_u64()) {
-                    return IrDecl::Alias {
-                        name: name.to_string(),
-                        docs,
-                        ty: IrType::Scalar {
-                            kind: Scalar::Integer,
-                            format: None,
-                        },
-                    };
-                }
-                let members = values
-                    .iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect();
+                let enum_values = if values.iter().all(|v| v.is_i64() || v.is_u64()) {
+                    EnumValues::Integers(values.iter().filter_map(|v| v.as_i64()).collect())
+                } else {
+                    EnumValues::Strings(
+                        values
+                            .iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect(),
+                    )
+                };
                 return IrDecl::Enum {
                     name: name.to_string(),
                     docs,
-                    members,
+                    values: enum_values,
                 };
             }
 
@@ -276,22 +367,30 @@ fn lower_decl(name: &str, schema: &Schema) -> IrDecl {
                 Vec::new()
             };
 
-            let _ = schema_type; // schema_type is informational here.
-            IrDecl::Struct(IrStruct {
-                name: name.to_string(),
-                docs,
-                fields,
-                has_unmodeled_variants: one_of.is_some() || any_of.is_some(),
-            })
+            // Object-shaped schemas become structs; a bare scalar/array schema
+            // at top level becomes a type alias.
+            let is_object =
+                schema_type_str(schema_type) == Some("object") || properties.is_some() || all_of.is_some();
+            if is_object {
+                IrDecl::Struct(IrStruct {
+                    name: name.to_string(),
+                    docs,
+                    fields,
+                    has_unmodeled_variants: one_of.is_some() || any_of.is_some(),
+                })
+            } else {
+                IrDecl::Alias {
+                    name: name.to_string(),
+                    docs,
+                    ty: lower_type(schema),
+                }
+            }
         }
-        // A top-level bare `$ref` (or anything else) becomes an opaque alias.
-        Schema::Reference { .. } => IrDecl::Alias {
+        // A top-level bare `$ref` becomes an alias to the referenced type.
+        Schema::Reference { reference, .. } => IrDecl::Alias {
             name: name.to_string(),
             docs,
-            ty: IrType::Scalar {
-                kind: Scalar::Free,
-                format: None,
-            },
+            ty: IrType::Named(ref_name(reference)),
         },
     }
 }
@@ -338,9 +437,9 @@ fn lower_type(schema: &Schema) -> IrType {
                 return IrType::Union(variants.iter().map(lower_type).collect());
             }
             if let Some(values) = enum_values {
-                // String enums keep their members (useful for literal-union
-                // backends); integer enums fall through to a plain integer.
-                if values.iter().any(|v| v.is_string()) {
+                // All-string enums become a closed set (literal union / Literal);
+                // integer or mixed enums fall through to a plain scalar.
+                if values.iter().all(|v| v.is_string()) {
                     let members = values
                         .iter()
                         .filter_map(|v| v.as_str().map(str::to_string))

--- a/src/generators/ir.rs
+++ b/src/generators/ir.rs
@@ -1,0 +1,322 @@
+//! Intermediate representation (IR) for code generation — PROPOSAL / FOR DISCUSSION.
+//!
+//! Today every generator under `src/generators/` consumes `&OpenApiSchema`
+//! directly and re-implements the same schema walking in slightly different
+//! ways (`$ref` resolution, nullable/optional handling, inline-object
+//! extraction, `oneOf`/`anyOf`/`allOf`, topological sorting). Bugs fixed in one
+//! generator do not get fixed in the others.
+//!
+//! This module proposes the classic compiler frontend/backend split:
+//!
+//! ```text
+//!   OpenApiSchema --lower()--> IrDocument --Backend--> target source
+//! ```
+//!
+//! `lower()` runs ONCE and absorbs all the gnarly OpenAPI-specific logic. Each
+//! backend then renders a clean, target-agnostic IR and never sees a `Schema`.
+//!
+//! Nothing is wired into the existing generators yet — this is here to react to
+//! in review. See the PR description for scope, migration path, and open
+//! questions.
+
+use crate::openapi::{OpenApiSchema, Schema, SchemaType};
+use indexmap::IndexMap;
+
+// ---------------------------------------------------------------------------
+// The IR
+// ---------------------------------------------------------------------------
+
+/// A scalar type, independent of any target language.
+///
+/// Each backend maps these to its own spelling, e.g. `Prim::Int` becomes
+/// `number` (TS), `int` (Python/C#), `i64` (Rust), `z.number().int()` (Zod).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Prim {
+    String,
+    Int,
+    Float,
+    Bool,
+    /// `format: binary` / byte payloads.
+    Bytes,
+    /// `format: date-time` / `date`.
+    DateTime,
+    /// No constraints — `any`/`object`/`unknown` depending on backend.
+    Any,
+}
+
+/// A target-agnostic type. No OpenAPI concepts leak past lowering: nullability,
+/// `$ref`, and inline objects are all already resolved into these variants.
+#[derive(Debug, Clone)]
+pub enum IrType {
+    Prim(Prim),
+    /// Reference to a top-level model by name (already normalized).
+    Named(String),
+    Array(Box<IrType>),
+    /// `additionalProperties` — a string-keyed map of the inner type.
+    Map(Box<IrType>),
+    /// `nullable` / not-`required` collapsed into one place.
+    Optional(Box<IrType>),
+    /// `oneOf` / `anyOf`.
+    Union(Vec<IrType>),
+    /// An anonymous inline object. Lowering MAY instead hoist these into named
+    /// `IrModel`s — see the open question in the PR description.
+    Object(IrObject),
+    /// A closed set of string values.
+    Enum(Vec<String>),
+}
+
+/// An object shape (fields + their types).
+#[derive(Debug, Clone, Default)]
+pub struct IrObject {
+    pub fields: Vec<IrField>,
+}
+
+/// One field of an object/model.
+#[derive(Debug, Clone)]
+pub struct IrField {
+    /// Name as it appears in the wire format (the JSON key).
+    pub wire_name: String,
+    pub ty: IrType,
+    /// Whether the field is required. Note `Optional` (nullable) is a property
+    /// of `ty`; this is the separate "may be absent" axis.
+    pub required: bool,
+    pub docs: Option<String>,
+}
+
+/// A named, top-level model (what becomes a `interface`/`class`/`struct`).
+#[derive(Debug, Clone)]
+pub struct IrModel {
+    pub name: String,
+    pub object: IrObject,
+    pub docs: Option<String>,
+}
+
+/// The whole lowered document handed to a backend.
+#[derive(Debug, Clone, Default)]
+pub struct IrDocument {
+    /// Topologically sorted so a backend can emit top-to-bottom without
+    /// forward references. (Lowering owns the sort that today lives in
+    /// `common.rs` and a duplicate in `python_dict.rs`.)
+    pub models: Vec<IrModel>,
+    // pub endpoints: Vec<IrEndpoint>,  // follow-up: lower paths/operations
+}
+
+// ---------------------------------------------------------------------------
+// Backend trait — a thin convention for the type-emitting generators.
+// ---------------------------------------------------------------------------
+
+/// Renders an [`IrDocument`] to a target language.
+///
+/// Deliberately NOT a per-node visitor (`render_array`, `render_optional`, …):
+/// that fights the borrow checker and forces awkward state threading. A single
+/// `type_ref` that recurses internally matches how the generators already work.
+pub trait Backend {
+    /// Render a type in reference position, e.g. the right-hand side of a field
+    /// declaration: `string | null`, `Optional[str]`, `z.string().nullable()`.
+    fn type_ref(&self, ty: &IrType) -> String;
+
+    /// Render one named model into `w`.
+    fn model(&self, model: &IrModel, w: &mut CodeWriter);
+
+    /// Imports / file header. Default: nothing.
+    fn preamble(&self, _doc: &IrDocument, _w: &mut CodeWriter) {}
+
+    /// Drive the whole document. Most backends won't need to override this.
+    fn render(&self, doc: &IrDocument) -> String {
+        let mut w = CodeWriter::new(self.indent_unit());
+        self.preamble(doc, &mut w);
+        for model in &doc.models {
+            self.model(model, &mut w);
+        }
+        w.finish()
+    }
+
+    /// The indentation unit for this language ("  " or "    ").
+    fn indent_unit(&self) -> &'static str {
+        "  "
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared writer — replaces the per-generator `indent_level` + `repeat` dance.
+// ---------------------------------------------------------------------------
+
+/// Accumulates source text with managed indentation. Replaces the
+/// `indent_level: usize` + `"  ".repeat(n)` pattern copied across generators.
+pub struct CodeWriter {
+    buf: String,
+    unit: &'static str,
+    level: usize,
+}
+
+impl CodeWriter {
+    pub fn new(unit: &'static str) -> Self {
+        Self {
+            buf: String::new(),
+            unit,
+            level: 0,
+        }
+    }
+
+    pub fn indent(&mut self) {
+        self.level += 1;
+    }
+
+    pub fn dedent(&mut self) {
+        self.level = self.level.saturating_sub(1);
+    }
+
+    /// Write one indented line (no trailing newline needed in `text`).
+    pub fn line(&mut self, text: &str) {
+        if text.is_empty() {
+            self.buf.push('\n');
+            return;
+        }
+        for _ in 0..self.level {
+            self.buf.push_str(self.unit);
+        }
+        self.buf.push_str(text);
+        self.buf.push('\n');
+    }
+
+    /// A blank separator line.
+    pub fn blank(&mut self) {
+        self.buf.push('\n');
+    }
+
+    pub fn finish(self) -> String {
+        self.buf
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lowering: OpenApiSchema -> IrDocument
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed OpenAPI document into the IR.
+///
+/// Partial implementation covering the common object/field cases — enough to
+/// show the shape against the real `Schema` type. `allOf` merging, full
+/// `oneOf`/`anyOf` discrimination, and path/operation lowering are intentionally
+/// left as follow-ups (see PR open questions).
+pub fn lower(schema: &OpenApiSchema) -> IrDocument {
+    let mut models = Vec::new();
+
+    if let Some(components) = &schema.components
+        && let Some(schemas) = &components.schemas
+    {
+        for (name, def) in schemas {
+            models.push(lower_model(name, def));
+        }
+        // NOTE: topological sort over `models` would happen here, reusing the
+        // single Kahn's-algorithm implementation from `common.rs`.
+    }
+
+    IrDocument { models }
+}
+
+fn lower_model(name: &str, schema: &Schema) -> IrModel {
+    let docs = schema.get_description().map(str::to_string);
+    let object = match schema {
+        Schema::Object {
+            properties,
+            required,
+            ..
+        } => lower_object(properties.as_ref(), required.as_ref()),
+        // A top-level `$ref` alias or scalar newtype: model with no fields for
+        // now; a real impl would carry a type alias variant.
+        Schema::Reference { .. } => IrObject::default(),
+    };
+    IrModel {
+        name: name.to_string(),
+        object,
+        docs,
+    }
+}
+
+fn lower_object(
+    properties: Option<&IndexMap<String, Schema>>,
+    required: Option<&Vec<String>>,
+) -> IrObject {
+    let mut fields = Vec::new();
+    if let Some(props) = properties {
+        for (field_name, field_schema) in props {
+            let is_required = required.is_some_and(|r| r.iter().any(|n| n == field_name));
+            let mut ty = lower_type(field_schema);
+            // Fold nullability into the type.
+            if field_schema.is_nullable() {
+                ty = IrType::Optional(Box::new(ty));
+            }
+            fields.push(IrField {
+                wire_name: field_name.clone(),
+                ty,
+                required: is_required,
+                docs: field_schema.get_description().map(str::to_string),
+            });
+        }
+    }
+    IrObject { fields }
+}
+
+/// Map a single `Schema` node to an `IrType`. This is the logic currently
+/// duplicated as `schema_to_typescript` / `schema_to_zod` / `schema_to_python_type`
+/// / etc. — here it lives exactly once.
+fn lower_type(schema: &Schema) -> IrType {
+    match schema {
+        Schema::Reference { reference, .. } => IrType::Named(ref_name(reference)),
+        Schema::Object {
+            schema_type,
+            items,
+            enum_values,
+            additional_properties,
+            one_of,
+            any_of,
+            format,
+            ..
+        } => {
+            if let Some(variants) = one_of.as_ref().or(any_of.as_ref()) {
+                return IrType::Union(variants.iter().map(lower_type).collect());
+            }
+            if let Some(values) = enum_values {
+                let members = values
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect();
+                return IrType::Enum(members);
+            }
+            match schema_type.as_ref().and_then(SchemaType::primary_type) {
+                Some("array") => {
+                    let inner = items.as_deref().map(lower_type).unwrap_or(IrType::Prim(Prim::Any));
+                    IrType::Array(Box::new(inner))
+                }
+                Some("object") | None => {
+                    if let Some(crate::openapi::AdditionalProperties::Schema(value)) =
+                        additional_properties
+                    {
+                        IrType::Map(Box::new(lower_type(value)))
+                    } else {
+                        IrType::Prim(Prim::Any)
+                    }
+                }
+                Some("string") => match format.as_deref() {
+                    Some("date-time") | Some("date") => IrType::Prim(Prim::DateTime),
+                    Some("binary") | Some("byte") => IrType::Prim(Prim::Bytes),
+                    _ => IrType::Prim(Prim::String),
+                },
+                Some("integer") => IrType::Prim(Prim::Int),
+                Some("number") => IrType::Prim(Prim::Float),
+                Some("boolean") => IrType::Prim(Prim::Bool),
+                _ => IrType::Prim(Prim::Any),
+            }
+        }
+    }
+}
+
+/// `#/components/schemas/Foo` -> `Foo`.
+fn ref_name(reference: &str) -> String {
+    reference
+        .rsplit('/')
+        .next()
+        .unwrap_or(reference)
+        .to_string()
+}

--- a/src/generators/ir.rs
+++ b/src/generators/ir.rs
@@ -45,7 +45,11 @@ pub enum Scalar {
     Integer,
     Number,
     Boolean,
-    /// Unconstrained — `object`/`any`/free-form JSON.
+    /// A typed-but-shapeless object (`type: object` with no properties) — a
+    /// string-keyed bag. Distinct from [`Scalar::Free`] so backends that have a
+    /// dictionary type (C#) can use it while others fall back to "any".
+    Object,
+    /// Unconstrained — no `type`, arbitrary JSON.
     Free,
 }
 
@@ -167,19 +171,34 @@ pub fn lower(schema: &OpenApiSchema) -> IrDocument {
     if let Some(components) = &schema.components
         && let Some(schemas) = &components.schemas
     {
-        // Reuse the single canonical topological sort (the one previously also
-        // re-implemented as a DFS in python_dict.rs). Fall back to natural order
-        // only if a cycle makes a total order impossible.
-        let names = common::topological_sort(schemas)
-            .unwrap_or_else(|_| schemas.keys().cloned().collect());
-        for name in names {
-            if let Some(def) = schemas.get(&name) {
-                decls.push(lower_decl(&name, def));
-            }
+        // Preserve source declaration order. Backends that cannot forward-
+        // reference opt into dependency ordering via `topologically_sorted`.
+        for (name, def) in schemas {
+            decls.push(lower_decl(name, def));
         }
     }
 
     IrDocument { decls }
+}
+
+/// Reorder a document's declarations into dependency (topological) order, so a
+/// backend that cannot forward-reference types can emit top-to-bottom. Reuses
+/// the single canonical sort in `common` (previously also re-implemented as a
+/// DFS in `python_dict.rs`). Backends that don't care keep source order.
+pub fn topologically_sorted(mut doc: IrDocument, schema: &OpenApiSchema) -> IrDocument {
+    if let Some(components) = &schema.components
+        && let Some(schemas) = &components.schemas
+        && let Ok(order) = common::topological_sort(schemas)
+    {
+        let rank: std::collections::HashMap<&str, usize> = order
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.as_str(), i))
+            .collect();
+        doc.decls
+            .sort_by_key(|d| rank.get(d.name()).copied().unwrap_or(usize::MAX));
+    }
+    doc
 }
 
 /// Classify a top-level schema into a declaration. Mirrors the structural
@@ -284,9 +303,14 @@ fn collect_fields(
 ) {
     for (field_name, field_schema) in props {
         let is_required = required.is_some_and(|r| r.iter().any(|n| n == field_name));
+        let mut ty = lower_type(field_schema);
+        // Keep schema-level nullability as a distinct axis from required.
+        if field_schema.is_nullable() {
+            ty = IrType::Optional(Box::new(ty));
+        }
         out.push(IrField {
             wire_name: field_name.clone(),
-            ty: lower_type(field_schema),
+            ty,
             required: is_required,
             docs: field_schema.get_description().map(str::to_string),
         });
@@ -342,7 +366,7 @@ fn lower_type(schema: &Schema) -> IrType {
                         IrType::Map(Box::new(lower_type(value)))
                     } else {
                         IrType::Scalar {
-                            kind: Scalar::Free,
+                            kind: Scalar::Object,
                             format: None,
                         }
                     }

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -3,6 +3,9 @@ pub mod common;
 pub mod dotnet;
 pub mod endpoints;
 pub mod import_generator;
+// Proposal / for discussion — not yet wired into the generators. See PR.
+#[allow(dead_code)]
+pub mod ir;
 pub mod json_schema;
 pub mod markdown;
 pub mod pydantic;

--- a/src/generators/python_dict.rs
+++ b/src/generators/python_dict.rs
@@ -1,14 +1,9 @@
 use crate::generators::Generator;
-use crate::openapi::{
-    AdditionalProperties, OpenApiSchema, Schema, is_schema_nullable, schema_type_str,
-};
+use crate::generators::ir::{self, Backend, EnumValues, IrDecl, IrField, IrStruct, IrType, Scalar};
+use crate::openapi::OpenApiSchema;
 use anyhow::Result;
-use indexmap::IndexMap;
-use std::collections::{HashMap, HashSet};
 
-pub struct PythonDictGenerator {
-    indent_level: usize,
-}
+pub struct PythonDictGenerator;
 
 impl Default for PythonDictGenerator {
     fn default() -> Self {
@@ -18,501 +13,136 @@ impl Default for PythonDictGenerator {
 
 impl PythonDictGenerator {
     pub fn new() -> Self {
-        Self { indent_level: 0 }
+        Self
     }
+}
 
-    fn indent(&self) -> String {
-        "    ".repeat(self.indent_level)
-    }
+/// Renders the shared [`ir::IrDocument`] as `typing.TypedDict` classes. The
+/// third generator migrated onto the IR.
+struct PythonDictBackend {
+    command: String,
+}
 
-    /// Collect all schema references (dependencies) from a schema
-    fn collect_dependencies(
-        &self,
-        schema: &Schema,
-        known_schemas: &HashSet<&str>,
-    ) -> HashSet<String> {
-        let mut deps = HashSet::new();
-        self.collect_dependencies_recursive(schema, known_schemas, &mut deps);
-        deps
-    }
-
-    fn collect_dependencies_recursive(
-        &self,
-        schema: &Schema,
-        known_schemas: &HashSet<&str>,
-        deps: &mut HashSet<String>,
-    ) {
-        match schema {
-            Schema::Reference { reference, .. } => {
-                if let Some(type_name) = reference.strip_prefix("#/components/schemas/")
-                    && known_schemas.contains(type_name)
-                {
-                    deps.insert(type_name.to_string());
-                }
-            }
-            Schema::Object {
-                properties,
-                items,
-                one_of,
-                any_of,
-                ..
-            } => {
-                if let Some(props) = properties {
-                    for prop_schema in props.values() {
-                        self.collect_dependencies_recursive(prop_schema, known_schemas, deps);
-                    }
-                }
-                if let Some(item_schema) = items {
-                    self.collect_dependencies_recursive(item_schema, known_schemas, deps);
-                }
-                if let Some(schemas) = one_of {
-                    for s in schemas {
-                        self.collect_dependencies_recursive(s, known_schemas, deps);
-                    }
-                }
-                if let Some(schemas) = any_of {
-                    for s in schemas {
-                        self.collect_dependencies_recursive(s, known_schemas, deps);
-                    }
-                }
-            }
+impl PythonDictBackend {
+    fn render_fields(&self, fields: &[&IrField], out: &mut String) {
+        for field in fields {
+            out.push_str(&format!("    {}: {}\n", field.wire_name, self.type_ref(&field.ty)));
         }
     }
 
-    /// Topologically sort schemas so dependencies come before dependents
-    fn topological_sort<'a>(
-        &self,
-        schemas: &'a IndexMap<String, Schema>,
-    ) -> Result<Vec<&'a String>> {
-        let known_schemas: HashSet<&str> = schemas.keys().map(|s| s.as_str()).collect();
-
-        // Build dependency graph
-        let mut dependencies: HashMap<&String, HashSet<String>> = HashMap::new();
-        for (name, schema) in schemas {
-            dependencies.insert(name, self.collect_dependencies(schema, &known_schemas));
+    fn render_struct(&self, s: &IrStruct, out: &mut String) {
+        if s.fields.is_empty() {
+            out.push_str(&format!("class {}(TypedDict):\n", s.name));
+            out.push_str("    pass\n\n");
+            return;
         }
 
-        // DFS-based topological sort
-        let mut result: Vec<&String> = Vec::new();
-        let mut visited: HashSet<&String> = HashSet::new();
-        let mut in_stack: HashSet<&String> = HashSet::new();
+        let required: Vec<&IrField> = s.fields.iter().filter(|f| f.required).collect();
+        let optional: Vec<&IrField> = s.fields.iter().filter(|f| !f.required).collect();
 
-        fn visit<'a>(
-            name: &'a String,
-            dependencies: &HashMap<&'a String, HashSet<String>>,
-            schemas: &'a IndexMap<String, Schema>,
-            visited: &mut HashSet<&'a String>,
-            in_stack: &mut HashSet<&'a String>,
-            result: &mut Vec<&'a String>,
-        ) -> Result<()> {
-            if in_stack.contains(name) {
-                // Circular dependency - skip to avoid infinite loop
-                return Ok(());
+        match (required.is_empty(), optional.is_empty()) {
+            // Mixed: a `*Required` base TypedDict plus a `total=False` subclass.
+            (false, false) => {
+                out.push_str(&format!("class {}Required(TypedDict):\n", s.name));
+                self.render_fields(&required, out);
+                out.push_str("\n\n");
+                out.push_str(&format!("class {}({}Required, total=False):\n", s.name, s.name));
+                self.render_fields(&optional, out);
+                out.push('\n');
             }
-            if visited.contains(name) {
-                return Ok(());
+            // All required.
+            (false, true) => {
+                out.push_str(&format!("class {}(TypedDict):\n", s.name));
+                self.render_fields(&required, out);
+                out.push('\n');
             }
-
-            in_stack.insert(name);
-
-            if let Some(deps) = dependencies.get(name) {
-                // Sort dependencies for deterministic order
-                let mut sorted_deps: Vec<&String> = deps.iter().collect();
-                sorted_deps.sort();
-                for dep in sorted_deps {
-                    if let Some(dep_name) = schemas.keys().find(|k| *k == dep) {
-                        visit(dep_name, dependencies, schemas, visited, in_stack, result)?;
-                    }
-                }
+            // All optional.
+            (true, false) => {
+                out.push_str(&format!("class {}(TypedDict, total=False):\n", s.name));
+                self.render_fields(&optional, out);
+                out.push('\n');
             }
-
-            in_stack.remove(name);
-            visited.insert(name);
-            result.push(name);
-
-            Ok(())
+            (true, true) => unreachable!("non-empty fields split into neither group"),
         }
+    }
+}
 
-        // Sort keys alphabetically for deterministic output order
-        let mut sorted_keys: Vec<&String> = schemas.keys().collect();
-        sorted_keys.sort();
-
-        for name in sorted_keys {
-            visit(
-                name,
-                &dependencies,
-                schemas,
-                &mut visited,
-                &mut in_stack,
-                &mut result,
-            )?;
+impl Backend for PythonDictBackend {
+    fn type_ref(&self, ty: &IrType) -> String {
+        match ty {
+            // Python 3.10+ union syntax for nullability.
+            IrType::Optional(inner) => format!("{} | None", self.type_ref(inner)),
+            IrType::Named(name) => name.clone(),
+            IrType::Array(inner) => format!("list[{}]", self.type_ref(inner)),
+            IrType::Map(value) => format!("dict[str, {}]", self.type_ref(value)),
+            IrType::Union(variants) => variants
+                .iter()
+                .map(|v| self.type_ref(v))
+                .collect::<Vec<_>>()
+                .join(" | "),
+            IrType::Enum(members) => {
+                let quoted: Vec<String> = members.iter().map(|m| format!("\"{m}\"")).collect();
+                format!("Literal[{}]", quoted.join(", "))
+            }
+            IrType::Scalar { kind, .. } => match kind {
+                Scalar::String => "str".to_string(),
+                Scalar::Integer => "int".to_string(),
+                Scalar::Number => "float".to_string(),
+                Scalar::Boolean => "bool".to_string(),
+                Scalar::Object => "dict[str, Any]".to_string(),
+                Scalar::Free => "Any".to_string(),
+            },
         }
-
-        Ok(result)
     }
 
-    fn generate_typed_dict(&self, name: &str, schema: &Schema) -> Result<String> {
-        let mut output = String::new();
-
-        match schema {
-            Schema::Object {
-                schema_type,
-                properties,
-                required,
-                additional_properties,
-                enum_values,
-
-                one_of,
-                any_of,
-                ..
-            } => {
-                // Handle enum types
-                if let Some(enum_vals) = enum_values {
-                    let all_int = enum_vals.iter().all(|v| v.is_i64() || v.is_u64());
-                    if all_int {
-                        output.push_str(&format!("{}class {}(IntEnum):\n", self.indent(), name));
-                        for enum_val in enum_vals {
-                            if let Some(n) = enum_val.as_i64() {
-                                let member = if n >= 0 {
-                                    format!("VALUE_{n}")
-                                } else {
-                                    format!("VALUE_NEG_{}", -n)
-                                };
-                                output.push_str(&format!(
-                                    "{}    {} = {}\n",
-                                    self.indent(),
-                                    member,
-                                    n
-                                ));
-                            }
-                        }
-                    } else {
-                        output.push_str(&format!("{}class {}(str, Enum):\n", self.indent(), name));
-                        for enum_val in enum_vals {
-                            if let Some(val_str) = enum_val.as_str() {
-                                let enum_name =
-                                    val_str.to_uppercase().replace(" ", "_").replace("-", "_");
-                                output.push_str(&format!(
-                                    "{}    {} = \"{}\"\n",
-                                    self.indent(),
-                                    enum_name,
-                                    val_str
-                                ));
-                            }
-                        }
-                    }
-                    output.push_str("\n\n");
-                    return Ok(output);
-                }
-
-                // Handle composition types (Python 3.10+ union syntax)
-                if let Some(one_of_schemas) = one_of {
-                    let types: Result<Vec<String>, _> = one_of_schemas
-                        .iter()
-                        .map(|s| self.schema_to_python_type(s))
-                        .collect();
-                    output.push_str(&format!(
-                        "{}{} = {}\n\n",
-                        self.indent(),
-                        name,
-                        types?.join(" | ")
-                    ));
-                    return Ok(output);
-                } else if let Some(any_of_schemas) = any_of {
-                    let types: Result<Vec<String>, _> = any_of_schemas
-                        .iter()
-                        .map(|s| self.schema_to_python_type(s))
-                        .collect();
-                    output.push_str(&format!(
-                        "{}{} = {}\n\n",
-                        self.indent(),
-                        name,
-                        types?.join(" | ")
-                    ));
-                    return Ok(output);
-                }
-
-                // Handle map types (additionalProperties without properties)
-                if properties.is_none()
-                    && matches!(additional_properties, Some(AdditionalProperties::Schema(_)))
-                {
-                    let py_type = self.schema_to_python_type(schema)?;
-                    output.push_str(&format!("{}{} = {}\n\n", self.indent(), name, py_type));
-                    return Ok(output);
-                }
-
-                // Handle object types
-                if schema_type_str(schema_type) == Some("object") || properties.is_some() {
-                    let empty_required = vec![];
-                    let required_fields: Vec<&String> = required
-                        .as_ref()
-                        .unwrap_or(&empty_required)
-                        .iter()
-                        .collect();
-
-                    if let Some(props) = properties {
-                        if props.is_empty() {
-                            output.push_str(&format!(
-                                "{}class {}(TypedDict):\n",
-                                self.indent(),
-                                name
-                            ));
-                            output.push_str(&format!("{}    pass\n", self.indent()));
-                        } else {
-                            let has_required = required_fields
-                                .iter()
-                                .any(|field| props.contains_key(*field));
-                            let has_optional =
-                                props.keys().any(|key| !required_fields.contains(&key));
-
-                            if has_required && has_optional {
-                                // Create base TypedDict for required fields
-                                output.push_str(&format!(
-                                    "{}class {}Required(TypedDict):\n",
-                                    self.indent(),
-                                    name
-                                ));
-                                for field_name in &required_fields {
-                                    if let Some(field_schema) = props.get(*field_name) {
-                                        let field_type =
-                                            self.schema_to_python_type(field_schema)?;
-                                        output.push_str(&format!(
-                                            "{}    {}: {}\n",
-                                            self.indent(),
-                                            field_name,
-                                            field_type
-                                        ));
-                                    }
-                                }
-                                output.push_str("\n\n");
-
-                                // Create full TypedDict that inherits from required and adds optional fields
-                                output.push_str(&format!(
-                                    "{}class {}({}Required, total=False):\n",
-                                    self.indent(),
-                                    name,
-                                    name
-                                ));
-                                for (prop_name, prop_schema) in props {
-                                    if !required_fields.contains(&prop_name) {
-                                        let field_type = self.schema_to_python_type(prop_schema)?;
-                                        output.push_str(&format!(
-                                            "{}    {}: {}\n",
-                                            self.indent(),
-                                            prop_name,
-                                            field_type
-                                        ));
-                                    }
-                                }
-                            } else if has_required {
-                                // Only required fields
-                                output.push_str(&format!(
-                                    "{}class {}(TypedDict):\n",
-                                    self.indent(),
-                                    name
-                                ));
-                                for (prop_name, prop_schema) in props {
-                                    let field_type = self.schema_to_python_type(prop_schema)?;
-                                    output.push_str(&format!(
-                                        "{}    {}: {}\n",
-                                        self.indent(),
-                                        prop_name,
-                                        field_type
-                                    ));
-                                }
+    fn decl(&self, decl: &IrDecl, out: &mut String) {
+        match decl {
+            IrDecl::Struct(s) => self.render_struct(s, out),
+            IrDecl::Enum { name, values, .. } => {
+                match values {
+                    EnumValues::Integers(ints) => {
+                        out.push_str(&format!("class {}(IntEnum):\n", name));
+                        for n in ints {
+                            let member = if *n >= 0 {
+                                format!("VALUE_{n}")
                             } else {
-                                // Only optional fields
-                                output.push_str(&format!(
-                                    "{}class {}(TypedDict, total=False):\n",
-                                    self.indent(),
-                                    name
-                                ));
-                                for (prop_name, prop_schema) in props {
-                                    let field_type = self.schema_to_python_type(prop_schema)?;
-                                    output.push_str(&format!(
-                                        "{}    {}: {}\n",
-                                        self.indent(),
-                                        prop_name,
-                                        field_type
-                                    ));
-                                }
-                            }
+                                format!("VALUE_NEG_{}", -n)
+                            };
+                            out.push_str(&format!("    {member} = {n}\n"));
                         }
-                    } else {
-                        output.push_str(&format!("{}class {}(TypedDict):\n", self.indent(), name));
-                        output.push_str(&format!("{}    pass\n", self.indent()));
                     }
-
-                    output.push('\n');
-                } else {
-                    // Handle primitive type aliases
-                    let py_type = self.schema_to_python_type(schema)?;
-                    output.push_str(&format!("{}{} = {}\n\n", self.indent(), name, py_type));
+                    EnumValues::Strings(members) => {
+                        out.push_str(&format!("class {}(str, Enum):\n", name));
+                        for member in members {
+                            let upper = member.to_uppercase().replace([' ', '-'], "_");
+                            out.push_str(&format!("    {upper} = \"{member}\"\n"));
+                        }
+                    }
                 }
+                out.push_str("\n\n");
             }
-            Schema::Reference { .. } => {
-                // For references, create a type alias
-                let py_type = self.schema_to_python_type(schema)?;
-                output.push_str(&format!("{}{} = {}\n\n", self.indent(), name, py_type));
+            IrDecl::Alias { name, ty, .. } => {
+                out.push_str(&format!("{} = {}\n\n", name, self.type_ref(ty)));
             }
         }
-
-        Ok(output)
     }
 
-    #[allow(clippy::only_used_in_recursion)]
-    fn schema_to_python_type(&self, schema: &Schema) -> Result<String> {
-        match schema {
-            Schema::Object {
-                schema_type,
-                properties,
-                additional_properties,
-                format,
-                enum_values,
-                items,
-                nullable,
-                one_of,
-                any_of,
-                ..
-            } => {
-                // Handle composition types (Python 3.10+ union syntax)
-                if let Some(one_of_schemas) = one_of {
-                    let types: Result<Vec<String>, _> = one_of_schemas
-                        .iter()
-                        .map(|s| self.schema_to_python_type(s))
-                        .collect();
-                    let union_type = types?.join(" | ");
-                    return Ok(if is_schema_nullable(nullable, schema_type) {
-                        format!("{union_type} | None")
-                    } else {
-                        union_type
-                    });
-                } else if let Some(any_of_schemas) = any_of {
-                    let types: Result<Vec<String>, _> = any_of_schemas
-                        .iter()
-                        .map(|s| self.schema_to_python_type(s))
-                        .collect();
-                    let union_type = types?.join(" | ");
-                    return Ok(if is_schema_nullable(nullable, schema_type) {
-                        format!("{union_type} | None")
-                    } else {
-                        union_type
-                    });
-                }
-
-                // Handle enum values
-                if let Some(enum_vals) = enum_values
-                    && enum_vals.iter().all(|v| v.is_string())
-                {
-                    let values: Vec<String> = enum_vals
-                        .iter()
-                        .filter_map(|v| v.as_str())
-                        .map(|s| format!("\"{s}\""))
-                        .collect();
-                    let literal_type = format!("Literal[{}]", values.join(", "));
-                    return Ok(if is_schema_nullable(nullable, schema_type) {
-                        format!("{literal_type} | None")
-                    } else {
-                        literal_type
-                    });
-                }
-
-                let base_type = if let Some(type_str) = schema_type_str(schema_type) {
-                    match type_str {
-                        "string" => match format.as_deref() {
-                            Some("email") => "str",
-                            Some("uri") | Some("url") => "str",
-                            Some("uuid") => "str",
-                            Some("date") => "str",
-                            Some("date-time") => "str",
-                            _ => "str",
-                        },
-                        "integer" => "int",
-                        "number" => "float",
-                        "boolean" => "bool",
-                        "array" => {
-                            if let Some(item_schema) = items {
-                                let item_type = self.schema_to_python_type(item_schema)?;
-                                return Ok(if is_schema_nullable(nullable, schema_type) {
-                                    format!("list[{item_type}] | None")
-                                } else {
-                                    format!("list[{item_type}]")
-                                });
-                            } else {
-                                "list[Any]"
-                            }
-                        }
-                        "object" => {
-                            if properties.is_none()
-                                && let Some(AdditionalProperties::Schema(ap_schema)) =
-                                    additional_properties
-                            {
-                                let value_type = self.schema_to_python_type(ap_schema)?;
-                                return Ok(if is_schema_nullable(nullable, schema_type) {
-                                    format!("dict[str, {value_type}] | None")
-                                } else {
-                                    format!("dict[str, {value_type}]")
-                                });
-                            }
-                            "dict[str, Any]"
-                        }
-                        _ => "Any",
-                    }
-                } else {
-                    "Any"
-                }
-                .to_string();
-
-                Ok(if is_schema_nullable(nullable, schema_type) {
-                    format!("{base_type} | None")
-                } else {
-                    base_type
-                })
-            }
-            Schema::Reference { reference, .. } => {
-                let type_name = reference
-                    .strip_prefix("#/components/schemas/")
-                    .unwrap_or(reference);
-                Ok(type_name.to_string())
-            }
-        }
+    fn preamble(&self, _doc: &ir::IrDocument, out: &mut String) {
+        out.push_str(&format!("# Generated by {}\n", self.command));
+        out.push_str("# Do not modify manually\n\n");
+        out.push_str("from typing import TypedDict, Literal, Any\n");
+        out.push_str("from enum import Enum, IntEnum\n");
+        out.push_str("from datetime import datetime\n\n");
     }
 }
 
 impl Generator for PythonDictGenerator {
     fn generate_with_command(&self, schema: &OpenApiSchema, command: &str) -> Result<String> {
-        let mut output = String::new();
-
-        // Add header comment
-        output.push_str(&format!("# Generated by {command}\n"));
-        output.push_str("# Do not modify manually\n\n");
-
-        // Add imports (Python 3.10+ syntax)
-        output.push_str("from typing import TypedDict, Literal, Any\n");
-        output.push_str("from enum import Enum, IntEnum\n");
-        output.push_str("from datetime import datetime\n\n");
-
-        if let Some(components) = &schema.components
-            && let Some(schemas) = &components.schemas
-        {
-            // Sort schemas topologically so dependencies come first
-            let sorted_names = self.topological_sort(schemas)?;
-            for name in sorted_names {
-                if let Some(schema_def) = schemas.get(name) {
-                    let typed_dict = self.generate_typed_dict(name, schema_def)?;
-                    output.push_str(&typed_dict);
-                }
-            }
-        }
-
-        Ok(output)
-    }
-}
-
-impl Clone for PythonDictGenerator {
-    fn clone(&self) -> Self {
-        Self {
-            indent_level: self.indent_level,
-        }
+        // Preserve the original generator's depth-first dependency ordering.
+        let document = ir::dfs_dependency_sorted(ir::lower(schema), schema);
+        let backend = PythonDictBackend {
+            command: command.to_string(),
+        };
+        Ok(backend.render(&document))
     }
 }

--- a/src/generators/rust_serde.rs
+++ b/src/generators/rust_serde.rs
@@ -1,6 +1,6 @@
 use crate::generators::Generator;
 use crate::generators::common;
-use crate::generators::ir::{self, Backend, IrDecl, IrField, IrStruct, IrType, Scalar};
+use crate::generators::ir::{self, Backend, EnumValues, IrDecl, IrField, IrStruct, IrType, Scalar};
 use crate::openapi::OpenApiSchema;
 use anyhow::Result;
 
@@ -115,16 +115,23 @@ impl Backend for RustBackend {
     fn decl(&self, decl: &IrDecl, out: &mut String) {
         match decl {
             IrDecl::Struct(s) => self.render_struct(s, out),
-            IrDecl::Enum { name, members, .. } => {
-                out.push_str("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n");
-                out.push_str("#[serde(rename_all = \"snake_case\")]\n");
-                out.push_str(&format!("pub enum {} {{\n", name));
-                for member in members {
-                    out.push_str(&format!("    #[serde(rename = \"{}\")]\n", member));
-                    out.push_str(&format!("    {},\n", Self::enum_variant(member)));
+            IrDecl::Enum { name, values, .. } => match values {
+                // Integer enums degrade to a plain integer alias (matching the
+                // original generator).
+                EnumValues::Integers(_) => {
+                    out.push_str(&format!("pub type {} = i64;\n\n", name));
                 }
-                out.push_str("}\n\n");
-            }
+                EnumValues::Strings(members) => {
+                    out.push_str("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n");
+                    out.push_str("#[serde(rename_all = \"snake_case\")]\n");
+                    out.push_str(&format!("pub enum {} {{\n", name));
+                    for member in members {
+                        out.push_str(&format!("    #[serde(rename = \"{}\")]\n", member));
+                        out.push_str(&format!("    {},\n", Self::enum_variant(member)));
+                    }
+                    out.push_str("}\n\n");
+                }
+            },
             IrDecl::Alias { name, ty, .. } => {
                 out.push_str(&format!("pub type {} = {};\n\n", name, self.type_ref(ty)));
             }

--- a/src/generators/rust_serde.rs
+++ b/src/generators/rust_serde.rs
@@ -1,6 +1,7 @@
 use crate::generators::Generator;
 use crate::generators::common;
-use crate::openapi::{AdditionalProperties, OpenApiSchema, Schema, schema_type_str};
+use crate::generators::ir::{self, Backend, IrDecl, IrField, IrStruct, IrType, Scalar};
+use crate::openapi::OpenApiSchema;
 use anyhow::Result;
 
 pub struct RustSerdeGenerator;
@@ -15,228 +16,19 @@ impl RustSerdeGenerator {
     pub fn new() -> Self {
         Self
     }
+}
 
-    fn to_snake_case(&self, name: &str) -> String {
-        let mut result = String::new();
-        let mut prev_was_upper = false;
+/// Renders the shared [`ir::IrDocument`] as Rust types with serde derives.
+///
+/// This is the first generator migrated onto the IR (see `ir.rs`): all
+/// schema-walking now happens once in `ir::lower`, and this backend only decides
+/// how the IR is spelled in Rust.
+struct RustBackend;
 
-        for (i, ch) in name.chars().enumerate() {
-            if ch.is_uppercase() {
-                if i > 0 && !prev_was_upper {
-                    result.push('_');
-                }
-                result.push(ch.to_lowercase().next().unwrap_or(ch));
-                prev_was_upper = true;
-            } else if ch == '-' || ch == ' ' {
-                if !result.ends_with('_') {
-                    result.push('_');
-                }
-                prev_was_upper = false;
-            } else {
-                result.push(ch);
-                prev_was_upper = false;
-            }
-        }
-
-        if result.is_empty() {
-            "field".to_string()
-        } else {
-            result
-        }
-    }
-
-    fn to_rust_type(&self, schema: &Schema) -> Result<String> {
-        match schema {
-            Schema::Reference { reference, .. } => {
-                let type_name = reference
-                    .strip_prefix("#/components/schemas/")
-                    .unwrap_or(reference)
-                    .to_string();
-                Ok(type_name)
-            }
-            Schema::Object {
-                schema_type,
-                properties,
-                additional_properties,
-                format,
-                enum_values,
-                items,
-                ..
-            } => {
-                if let Some(enum_vals) = enum_values {
-                    if enum_vals.iter().all(|v| v.is_string()) {
-                        return Ok("String".to_string());
-                    }
-                    if enum_vals.iter().all(|v| v.is_i64() || v.is_u64()) {
-                        return Ok("i64".to_string());
-                    }
-                }
-
-                match schema_type_str(schema_type) {
-                    Some("string") => match format.as_deref() {
-                        Some("date") => Ok("String".to_string()),
-                        Some("date-time") => Ok("String".to_string()),
-                        Some("uuid") => Ok("String".to_string()),
-                        Some("email") => Ok("String".to_string()),
-                        Some("uri") | Some("url") => Ok("String".to_string()),
-                        _ => Ok("String".to_string()),
-                    },
-                    Some("integer") => match format.as_deref() {
-                        Some("int32") => Ok("i32".to_string()),
-                        Some("int64") => Ok("i64".to_string()),
-                        _ => Ok("i64".to_string()),
-                    },
-                    Some("number") => match format.as_deref() {
-                        Some("float") => Ok("f32".to_string()),
-                        Some("double") => Ok("f64".to_string()),
-                        _ => Ok("f64".to_string()),
-                    },
-                    Some("boolean") => Ok("bool".to_string()),
-                    Some("array") => {
-                        if let Some(items_schema) = items {
-                            let item_type = self.to_rust_type(items_schema)?;
-                            Ok(format!("Vec<{}>", item_type))
-                        } else {
-                            Ok("Vec<serde_json::Value>".to_string())
-                        }
-                    }
-                    Some("object") => {
-                        if properties.is_none()
-                            && let Some(AdditionalProperties::Schema(ap_schema)) =
-                                additional_properties
-                        {
-                            let value_type = self.to_rust_type(ap_schema)?;
-                            return Ok(format!("std::collections::HashMap<String, {value_type}>"));
-                        }
-                        Ok("serde_json::Value".to_string())
-                    }
-                    _ => Ok("serde_json::Value".to_string()),
-                }
-            }
-        }
-    }
-
-    fn generate_struct(&self, name: &str, schema: &Schema) -> Result<String> {
-        let mut output = String::new();
-
-        match schema {
-            Schema::Object {
-                properties,
-                required,
-                additional_properties,
-                enum_values,
-                all_of,
-                one_of,
-                any_of,
-                ..
-            } => {
-                // Handle map types (additionalProperties without properties)
-                if properties.is_none()
-                    && matches!(additional_properties, Some(AdditionalProperties::Schema(_)))
-                {
-                    let rust_type = self.to_rust_type(schema)?;
-                    output.push_str(&format!("pub type {} = {};\n\n", name, rust_type));
-                    return Ok(output);
-                }
-
-                if let Some(enum_vals) = enum_values {
-                    if enum_vals.iter().all(|v| v.is_i64() || v.is_u64()) {
-                        output.push_str(&format!("pub type {} = i64;\n\n", name));
-                        return Ok(output);
-                    }
-
-                    output.push_str("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n");
-                    output.push_str("#[serde(rename_all = \"snake_case\")]\n");
-                    output.push_str(&format!("pub enum {} {{\n", name));
-
-                    for enum_val in enum_vals {
-                        if let Some(val_str) = enum_val.as_str() {
-                            let variant_name = self.to_rust_enum_variant(val_str);
-                            output.push_str(&format!("    #[serde(rename = \"{}\")]\n", val_str));
-                            output.push_str(&format!("    {},\n", variant_name));
-                        }
-                    }
-
-                    output.push_str("}\n\n");
-                    return Ok(output);
-                }
-
-                output.push_str("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n");
-                output.push_str("#[serde(rename_all = \"camelCase\")]\n");
-                output.push_str(&format!("pub struct {} {{\n", name));
-
-                if let Some(all_of_schemas) = all_of {
-                    for schema in all_of_schemas.iter() {
-                        if let Schema::Object {
-                            properties: Some(props),
-                            required: req,
-                            ..
-                        } = schema
-                        {
-                            for (prop_name, prop_schema) in props {
-                                let field_name = self.to_snake_case(prop_name);
-                                let field_type = self.to_rust_type(prop_schema)?;
-                                let is_required =
-                                    req.as_ref().map(|r| r.contains(prop_name)).unwrap_or(false);
-
-                                let final_type = if !is_required {
-                                    format!("Option<{}>", field_type)
-                                } else {
-                                    field_type
-                                };
-
-                                if prop_name != &field_name {
-                                    output.push_str(&format!(
-                                        "    #[serde(rename = \"{}\")]\n",
-                                        prop_name
-                                    ));
-                                }
-                                output.push_str(&format!(
-                                    "    pub {}: {},\n",
-                                    field_name, final_type
-                                ));
-                            }
-                        }
-                    }
-                } else if let Some(props) = properties {
-                    for (prop_name, prop_schema) in props {
-                        let field_name = self.to_snake_case(prop_name);
-                        let field_type = self.to_rust_type(prop_schema)?;
-                        let is_required = required
-                            .as_ref()
-                            .map(|req| req.contains(prop_name))
-                            .unwrap_or(false);
-
-                        let final_type = if !is_required {
-                            format!("Option<{}>", field_type)
-                        } else {
-                            field_type
-                        };
-
-                        if prop_name != &field_name {
-                            output.push_str(&format!("    #[serde(rename = \"{}\")]\n", prop_name));
-                        }
-                        output.push_str(&format!("    pub {}: {},\n", field_name, final_type));
-                    }
-                }
-
-                if one_of.is_some() || any_of.is_some() {
-                    output.push_str(
-                        "    // Note: oneOf/anyOf schemas are combined as optional fields\n",
-                    );
-                }
-
-                output.push_str("}\n\n");
-            }
-            _ => {
-                output.push_str(&format!("pub type {} = serde_json::Value;\n\n", name));
-            }
-        }
-
-        Ok(output)
-    }
-
-    fn to_rust_enum_variant(&self, value: &str) -> String {
+impl RustBackend {
+    /// Render an enum variant identifier from a wire value, e.g. `low-stock`
+    /// or `low_stock` -> `LowStock`.
+    fn enum_variant(value: &str) -> String {
         let mut result = String::new();
         let mut capitalize_next = true;
 
@@ -259,26 +51,94 @@ impl RustSerdeGenerator {
             result
         }
     }
+
+    fn render_field(&self, field: &IrField, out: &mut String) {
+        let field_name = common::to_snake_case(&field.wire_name);
+        let base_type = self.type_ref(&field.ty);
+        let final_type = if field.required {
+            base_type
+        } else {
+            format!("Option<{}>", base_type)
+        };
+
+        if field.wire_name != field_name {
+            out.push_str(&format!("    #[serde(rename = \"{}\")]\n", field.wire_name));
+        }
+        out.push_str(&format!("    pub {}: {},\n", field_name, final_type));
+    }
+
+    fn render_struct(&self, s: &IrStruct, out: &mut String) {
+        out.push_str("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n");
+        out.push_str("#[serde(rename_all = \"camelCase\")]\n");
+        out.push_str(&format!("pub struct {} {{\n", s.name));
+        for field in &s.fields {
+            self.render_field(field, out);
+        }
+        if s.has_unmodeled_variants {
+            out.push_str("    // Note: oneOf/anyOf schemas are combined as optional fields\n");
+        }
+        out.push_str("}\n\n");
+    }
+}
+
+impl Backend for RustBackend {
+    fn type_ref(&self, ty: &IrType) -> String {
+        match ty {
+            // Rust models optionality via `Option<T>` driven by `required`, so a
+            // nullable inner type is rendered transparently here.
+            IrType::Optional(inner) => self.type_ref(inner),
+            IrType::Named(name) => name.clone(),
+            IrType::Array(inner) => format!("Vec<{}>", self.type_ref(inner)),
+            IrType::Map(value) => {
+                format!("std::collections::HashMap<String, {}>", self.type_ref(value))
+            }
+            // Inline string enums and unmodeled unions degrade to opaque values,
+            // matching the original generator.
+            IrType::Enum(_) => "String".to_string(),
+            IrType::Union(_) => "serde_json::Value".to_string(),
+            IrType::Scalar { kind, format } => match kind {
+                Scalar::String => "String".to_string(),
+                Scalar::Boolean => "bool".to_string(),
+                Scalar::Integer => match format.as_deref() {
+                    Some("int32") => "i32".to_string(),
+                    _ => "i64".to_string(),
+                },
+                Scalar::Number => match format.as_deref() {
+                    Some("float") => "f32".to_string(),
+                    _ => "f64".to_string(),
+                },
+                Scalar::Free => "serde_json::Value".to_string(),
+            },
+        }
+    }
+
+    fn decl(&self, decl: &IrDecl, out: &mut String) {
+        match decl {
+            IrDecl::Struct(s) => self.render_struct(s, out),
+            IrDecl::Enum { name, members, .. } => {
+                out.push_str("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n");
+                out.push_str("#[serde(rename_all = \"snake_case\")]\n");
+                out.push_str(&format!("pub enum {} {{\n", name));
+                for member in members {
+                    out.push_str(&format!("    #[serde(rename = \"{}\")]\n", member));
+                    out.push_str(&format!("    {},\n", Self::enum_variant(member)));
+                }
+                out.push_str("}\n\n");
+            }
+            IrDecl::Alias { name, ty, .. } => {
+                out.push_str(&format!("pub type {} = {};\n\n", name, self.type_ref(ty)));
+            }
+        }
+    }
+
+    fn preamble(&self, _doc: &ir::IrDocument, out: &mut String) {
+        out.push_str("use serde::{Deserialize, Serialize};\n\n");
+    }
 }
 
 impl Generator for RustSerdeGenerator {
     fn generate_with_command(&self, schema: &OpenApiSchema, _command: &str) -> Result<String> {
-        let mut output = String::new();
-
-        output.push_str("use serde::{Deserialize, Serialize};\n\n");
-
-        if let Some(components) = &schema.components
-            && let Some(schemas) = &components.schemas
-        {
-            let sorted_names = common::topological_sort(schemas)?;
-
-            for name in sorted_names {
-                if let Some(schema) = schemas.get(&name) {
-                    output.push_str(&self.generate_struct(&name, schema)?);
-                }
-            }
-        }
-
-        Ok(output)
+        let document = ir::lower(schema);
+        Ok(RustBackend.render(&document))
     }
 }

--- a/src/generators/rust_serde.rs
+++ b/src/generators/rust_serde.rs
@@ -107,7 +107,7 @@ impl Backend for RustBackend {
                     Some("float") => "f32".to_string(),
                     _ => "f64".to_string(),
                 },
-                Scalar::Free => "serde_json::Value".to_string(),
+                Scalar::Object | Scalar::Free => "serde_json::Value".to_string(),
             },
         }
     }
@@ -138,7 +138,9 @@ impl Backend for RustBackend {
 
 impl Generator for RustSerdeGenerator {
     fn generate_with_command(&self, schema: &OpenApiSchema, _command: &str) -> Result<String> {
-        let document = ir::lower(schema);
+        // Rust has no forward-reference problem in a single file, but the
+        // original generator emitted types in dependency order; preserve that.
+        let document = ir::topologically_sorted(ir::lower(schema), schema);
         Ok(RustBackend.render(&document))
     }
 }


### PR DESCRIPTION
> **⏸️ Status: postponed — converted to draft.** This was an exploratory proof of concept, not slated to merge for now. Three backends (rust-serde, dotnet, python-dict) were migrated onto the IR with byte-identical golden output to show the approach works; the remaining generators (Pydantic, TypeScript, Zod) need larger IR growth (validation constraints, composition-as-declaration, validator chains) and were not attempted. Kept open as a draft for reference if the harmonization effort is picked up later.

---

## Why

~11 generators under `src/generators/` (≈6200 lines) all consume `&OpenApiSchema` and return `Result<String>`, and most re-implement the same work in slightly different ways. The drift is the real cost: a bug fixed in one generator's schema-walking (e.g. nullable handling) doesn't reach the others.

This PR is a **discussion artifact** — it adds `src/generators/ir.rs` (a target-agnostic IR + `lower()` frontend + a thin `Backend` trait) but wires nothing in. It's marked `#[allow(dead_code)]`, compiles, and passes `clippy -D warnings`. The point is to react to the actual `enum IrType` shape inline.

## Two kinds of duplication

**1. Mechanical helpers** — easy, no architecture needed, can be done independently:

| Concern | Duplicated at |
|---|---|
| `to_pascal_case` | `common.rs:52`, `dotnet.rs:26` |
| `to_camel_case` | `common.rs` (`summary_to_camel_case`), `angular.rs:844` |
| `to_snake_case` | `pydantic.rs:39`, `rust_serde.rs:19` |
| Indentation | `"  ".repeat(n)` (ts/zod) vs `"    ".repeat(n)` (python/dotnet) |
| Topological sort | Kahn's in `common.rs:241`; a separate DFS reimpl in `python_dict.rs:83` |
| Dependency collection | `common.rs:183`, `python_dict.rs:29` |

**2. Schema-walking + type-mapping** — the structural duplication this proposal targets. Every type-emitter re-implements "match on `Schema`, resolve `$ref`, handle `oneOf`/`anyOf`/`allOf`/nullable/inline objects, decide optionality":
`typescript.rs:230` `schema_to_typescript` · `zod.rs:100` `schema_to_zod` · `pydantic.rs:250` · `python_dict.rs:310` · plus dotnet/rust_serde.

## The idea

Classic compiler frontend/backend split — lower OpenAPI → IR **once**, then each backend renders IR → syntax:

```
OpenApiSchema --lower()--> IrDocument --Backend--> target source
```

All the gnarly logic (`$ref` resolution, optionality, inline-object extraction, topo sort) lives in `lower()` exactly once. Backends never see a `Schema`. The `Backend` trait is intentionally **not** a per-node visitor — a single `type_ref(&IrType) -> String` that recurses internally matches how the generators already work and avoids fighting the borrow checker.

A shared `CodeWriter` (in the same module) replaces the per-generator `indent_level` + `repeat` dance.

## Scope — which generators fit

The **IR is the harmonizing force**; the trait is just a convention for type-emitters.

- **Fits cleanly (core win):** TypeScript, Pydantic, PythonDict, DotNet, RustSerde
- **Fits with a twist:** Zod renders *validators* not types, but already has a structured `ZodValue` enum — either make it a `Backend` whose `type_ref` returns validator chains, or let `ZodValue` inform `IrType`.
- **Consumes IR partially:** Angular (IR for DTOs, keeps its path/operation logic), Markdown & Endpoints (read IR, render prose/tables).
- **Different direction:** JSON Schema goes OpenAPI→JSON Schema; can ignore the trait.

## Migration path (low risk, golden-test gated)

1. Move naming/indent/topo helpers into `common.rs`; delete copies. *(Independent of the IR.)*
2. Land `IrType`/`IrModel` + `lower()` (this PR), golden-test the lowering.
3. Convert **one** small backend (RustSerde or DotNet, ~300 lines) keeping golden output byte-identical — validates the IR shape against a real target.
4. Convert the rest one at a time, each gated by existing golden tests.

## Open questions

- Should Zod's `ZodValue` be generalized into the IR, or stay a separate backend concern?
- How much of Angular's service generation can live on `IrDocument.endpoints` vs. staying bespoke?
- Should `lower()` fully resolve `allOf` merges, or keep composition in the IR?
- Is `type_ref -> String` enough, or do some targets need the writer for multi-line types?

The current `lower()` covers the common object/field/type cases; `allOf` merging, full `oneOf`/`anyOf` discrimination, and path/operation lowering are flagged as follow-ups in the code.


---

### Demo: `--rust-serde` now runs through the IR (commit e100797)

Connected the first backend end-to-end to prove the concept.

**What changed**
- `ir.rs` — fleshed out `IrType`/`IrDecl` + `lower()`: struct/enum/integer-enum/map/alias classification, `$ref` resolution, `allOf` flattening, and reuse of the canonical `common::topological_sort`. Added a thin `Backend` trait.
- `rust_serde.rs` — reimplemented as a `RustBackend` over the IR. **All** schema-walking now happens once in `lower()`; the backend only decides how the IR is spelled in Rust (serde renames, `Option<T>` from `required`, `i32`/`i64`/`f32`/`f64` from `format`).
- `common.rs` — added shared `to_snake_case` (was duplicated in `rust_serde` and `pydantic`).

**Results**
- Both `rust-serde` golden tests (`simple` + `full`) pass **byte-for-byte** — no fixture changes.
- Full test suite (13 tests) and `clippy --all-targets -- -D warnings` are green.

**On the "must also support JSON Schema and plain JSON" point**

It does, for free. The CLI already converts `--from-json` and `--from-json-schema` into `OpenApiSchema` *before* any generator runs (`lib.rs:191–225`). Since `lower()` consumes `OpenApiSchema`, that's the single convergence point — the IR is the second one, downstream. Verified the same `--rust-serde` path produces correct Rust from all three:

```
dtolator --from-openapi      simple-sample.json        --rust-serde   # byte-identical to golden
dtolator --from-json         test-data-simple.json     --rust-serde   # structs from a JSON sample
dtolator --from-json-schema  test-zod-all-features.json --rust-serde   # structs from a JSON Schema
```

So the frontend/backend picture is: **{OpenAPI, JSON, JSON Schema} → `OpenApiSchema` → `lower()` → `IrDocument` → backend → source.** New backends inherit all three input formats automatically.

**Notable IR design point surfaced by the demo:** Rust derives optionality purely from `required` and ignores `nullable`, whereas TypeScript uses both. The IR keeps these on separate axes (`IrField.required` vs `IrType::Optional`) so each backend combines them its own way — `RustBackend::type_ref` renders through `Optional` and wraps `Option<T>` based on `required`.

Next candidate to migrate: DotNet (similar size), which will validate the IR against a second target before tackling the larger ones.
